### PR TITLE
Fixed PR-AWS-CFR-SG-030: Publicly exposed DB Ports

### DIFF
--- a/security_group/security_group.yaml
+++ b/security_group/security_group.yaml
@@ -1,13 +1,13 @@
-AWSTemplateFormatVersion: 2010-09-09
+AWSTemplateFormatVersion: '2010-09-09'
 Metadata:
   License: Apache-2.0
 Description: >-
-  AWS CloudFormation Sample Template EC2InstanceWithSecurityGroupSample: Create
-  an Amazon EC2 instance running the Amazon Linux AMI. The AMI is chosen based
-  on the region in which the stack is run. This example creates an EC2 security
-  group for the instance to give you SSH access. **WARNING** This template
-  creates an Amazon EC2 instance. You will be billed for the AWS resources used
-  if you create a stack from this template.
+  AWS CloudFormation Sample Template EC2InstanceWithSecurityGroupSample: Create an
+  Amazon EC2 instance running the Amazon Linux AMI. The AMI is chosen based on the
+  region in which the stack is run. This example creates an EC2 security group for
+  the instance to give you SSH access. **WARNING** This template creates an Amazon
+  EC2 instance. You will be billed for the AWS resources used if you create a stack
+  from this template.
 Parameters:
   InstanceType:
     Description: WebServer EC2 instance type
@@ -62,186 +62,120 @@ Parameters:
     Type: String
     MinLength: 9
     MaxLength: 18
-    Default: 0.0.0.0/0
-    AllowedPattern: '(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})/(\d{1,2})'
+    Default: '0.0.0.0/0'
+    AllowedPattern: (\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})/(\d{1,2})
     ConstraintDescription: must be a valid IP CIDR range of the form x.x.x.x/x.
   LatestAmiId:
-    Type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
     Default: /aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2
 Resources:
   EC2Instance:
-    Type: 'AWS::EC2::Instance'
+    Type: AWS::EC2::Instance
     Properties:
-      InstanceType: !Ref InstanceType
+      InstanceType: !Ref 'InstanceType'
       SecurityGroups:
-        - !Ref InstanceSecurityGroup
-      ImageId: !Ref LatestAmiId
+        - !Ref 'InstanceSecurityGroup'
+      ImageId: !Ref 'LatestAmiId'
   InstanceSecurityGroup:
-    Type: 'AWS::EC2::SecurityGroup'
+    Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: Enable SSH access via internet
       GroupName: default
       SecurityGroupIngress:
         - IpProtocol: tcp
-          FromPort: '8080'
-          ToPort: '8080'
-          CidrIp: 0.0.0.0/0
-        - IpProtocol: tcp
           FromPort: '445'
           ToPort: '445'
-          CidrIp: 0.0.0.0/0
+          CidrIp: '0.0.0.0/0'
         - IpProtocol: tcp
           FromPort: '53'
           ToPort: '53'
-          CidrIp: 0.0.0.0/0
+          CidrIp: '0.0.0.0/0'
         - IpProtocol: tcp
           FromPort: '20'
           ToPort: '23'
-          CidrIp: 0.0.0.0/0
+          CidrIp: '0.0.0.0/0'
         - IpProtocol: tcp
           FromPort: '20'
           ToPort: '20'
-          CidrIp: 0.0.0.0/0
+          CidrIp: '0.0.0.0/0'
         - IpProtocol: tcp
           FromPort: '4333'
           ToPort: '4333'
-          CidrIp: 0.0.0.0/0
-        - IpProtocol: tcp
-          FromPort: '3306'
-          ToPort: '3306'
-          CidrIp: 0.0.0.0/0
+          CidrIp: '0.0.0.0/0'
         - IpProtocol: tcp
           FromPort: '137'
           ToPort: '137'
-          CidrIpv6: '::/0'
+          CidrIpv6: ::/0
         - IpProtocol: tcp
           FromPort: '138'
           ToPort: '138'
-          CidrIpv6: '::/0'
-        - IpProtocol: tcp
-          FromPort: '5432'
-          ToPort: '5432'
-          CidrIpv6: '::/0'
+          CidrIpv6: ::/0
         - IpProtocol: tcp
           FromPort: '3389'
           ToPort: '3389'
-          CidrIpv6: '::/0'
+          CidrIpv6: ::/0
         - IpProtocol: tcp
           FromPort: '25'
           ToPort: '25'
-          CidrIpv6: '::/0'
-        - IpProtocol: tcp
-          FromPort: '1433'
-          ToPort: '1433'
-          CidrIpv6: '::/0'
+          CidrIpv6: ::/0
         - IpProtocol: tcp
           FromPort: '1434'
           ToPort: '1434'
-          CidrIpv6: '::/0'
+          CidrIpv6: ::/0
         - IpProtocol: tcp
           FromPort: '23'
           ToPort: '23'
-          CidrIpv6: '::/0'
+          CidrIpv6: ::/0
         - IpProtocol: tcp
           FromPort: '5500'
           ToPort: '5500'
-          CidrIpv6: '::/0'
+          CidrIpv6: ::/0
         - IpProtocol: tcp
           FromPort: '5900'
           ToPort: '5900'
-          CidrIpv6: '::/0'
+          CidrIpv6: ::/0
         - IpProtocol: tcp
           FromPort: '135'
           ToPort: '135'
-          CidrIpv6: '::/0'
+          CidrIpv6: ::/0
         - IpProtocol: tcp
           FromPort: '22'
           ToPort: '22'
-          CidrIpv6: '::/0'
+          CidrIpv6: ::/0
         - IpProtocol: '-1'
           FromPort: '22'
           ToPort: '22'
-          CidrIpv6: '::/0'
-        - IpProtocol: tcp
-          FromPort: '8080'
-          ToPort: '8080'
-          CidrIp: 0.0.0.0/0
+          CidrIpv6: ::/0
         - IpProtocol: tcp
           FromPort: '8001'
           ToPort: '8001'
-          CidrIpv6: '::/0'
+          CidrIpv6: ::/0
         - IpProtocol: tcp
           FromPort: '8332'
           ToPort: '8333'
-          CidrIpv6: '::/0'
+          CidrIpv6: ::/0
         - IpProtocol: tcp
           FromPort: '8545'
           ToPort: '8545'
-          CidrIpv6: '::/0'
+          CidrIpv6: ::/0
         - IpProtocol: tcp
           FromPort: '30303'
           ToPort: '30303'
-          CidrIp: 0.0.0.0/0
-        - IpProtocol: tcp
-          FromPort: '1521'
-          ToPort: '1521'
-          CidrIp: 0.0.0.0/0
-        - IpProtocol: tcp
-          FromPort: '5000'
-          ToPort: '5000'
-          CidrIp: 0.0.0.0/0
-        - IpProtocol: tcp
-          FromPort: '5984'
-          ToPort: '5984'
-          CidrIpv6: '::/0'
-        - IpProtocol: tcp
-          FromPort: '6379'
-          ToPort: '6380'
-          CidrIpv6: '::/0'
-        - IpProtocol: tcp
-          FromPort: '9042'
-          ToPort: '9042'
-          CidrIpv6: '::/0'
-        - IpProtocol: tcp
-          FromPort: '11211'
-          ToPort: '11211'
-          CidrIpv6: '::/0'
-        - IpProtocol: tcp
-          FromPort: '27017'
-          ToPort: '27017'
-          CidrIpv6: '::/0'
-        - IpProtocol: tcp
-          FromPort: '28015'
-          ToPort: '28015'
-          CidrIpv6: '::/0'
-        - IpProtocol: tcp
-          FromPort: '29015'
-          ToPort: '29015'
-          CidrIpv6: '::/0'
-        - IpProtocol: tcp
-          FromPort: '50000'
-          ToPort: '50000'
-          CidrIpv6: '::/0'
+          CidrIp: '0.0.0.0/0'
         - IpProtocol: tcp
           FromPort: '69'
           ToPort: '69'
-          CidrIpv6: '::/0'
+          CidrIpv6: ::/0
 Outputs:
   InstanceId:
     Description: InstanceId of the newly created EC2 instance
-    Value: !Ref EC2Instance
+    Value: !Ref 'EC2Instance'
   AZ:
     Description: Availability Zone of the newly created EC2 instance
-    Value: !GetAtt 
-      - EC2Instance
-      - AvailabilityZone
+    Value: !GetAtt 'EC2Instance.AvailabilityZone'
   PublicDNS:
     Description: Public DNSName of the newly created EC2 instance
-    Value: !GetAtt 
-      - EC2Instance
-      - PublicDnsName
+    Value: !GetAtt 'EC2Instance.PublicDnsName'
   PublicIP:
     Description: Public IP address of the newly created EC2 instance
-    Value: !GetAtt 
-      - EC2Instance
-      - PublicIp
+    Value: !GetAtt 'EC2Instance.PublicIp'


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-SG-030 

 **Violation Description:** 

 DB Servers contain sensitive data and should not be exposed to any direct traffic from internet. This policy checks for the network traffic from internet hitting the DB Servers on their default ports. The DB servers monitored on the default ports are : Microsoft SQL Server (1433), Oracle (1521), MySQL (3306), Sybase (5000), Postgresql (5432), CouchDB (5984), Redis (6379, 6380), RethinkDB (8080,28015, 29015), CassandraDB (9042), Memcached (11211), MongoDB (27017), DB2 (50000). 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented at this URL: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group.html