### PR TITLE
Fixed PR-AWS-CFR-MQ-002: Ensure Amazon MQ Broker logging is enabled

### DIFF
--- a/mq/mq.yaml
+++ b/mq/mq.yaml
@@ -1,17 +1,18 @@
-AWSTemplateFormatVersion: 2010-09-09
-Description: "Create a basic Amazon MQ for RabbitMQ broker"
-Resources: 
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Create a basic Amazon MQ for RabbitMQ broker
+Resources:
   BasicBroker:
-    Type: "AWS::AmazonMQ::Broker"
-    Properties: 
-      AutoMinorVersionUpgrade: "false"
+    Type: AWS::AmazonMQ::Broker
+    Properties:
+      AutoMinorVersionUpgrade: 'false'
       BrokerName: MyBasicRabbitBroker
       DeploymentMode: SINGLE_INSTANCE
       EngineType: RabbitMQ
-      EngineVersion: "3.8.6"
+      EngineVersion: 3.8.6
       HostInstanceType: mq.t3.micro
-      PubliclyAccessible: "true"
-      Users: 
-        - 
-          Password: AmazonMqPassword            
+      PubliclyAccessible: 'true'
+      Users:
+        - Password: AmazonMqPassword
           Username: AmazonMqUsername
+      Logs:
+        - General: true


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-MQ-002 

 **Violation Description:** 

 Amazon MQ is integrated with CloudTrail and provides a record of the Amazon MQ calls made by a user, role, or AWS service. It supports logging both the request parameters and the responses for APIs as events in CloudTrail 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented at this URL: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-amazonmq-broker.html#cfn-amazonmq-broker-publiclyaccessible