### PR TITLE
Fixed PR-AWS-CFR-BKP-001: Ensure Glacier Backup policy is not publicly accessible

### DIFF
--- a/backup/backup.json
+++ b/backup/backup.json
@@ -59,7 +59,7 @@
                     "Statement": [
                         {
                             "Sid": "Vault-Access-Policy",
-                            "Effect": "Allow",
+                            "Effect": "deny",
                             "Principal": "*",
                             "Action": "backup:DeleteRecoveryPoint",
                             "Resource": [


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-BKP-001 

 **Violation Description:** 

 Public Glacier backup potentially expose existing interfaces to unwanted 3rd parties that can tap into an existing data stream, resulting in data leak to an unwanted party. 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented at this URL: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-backup-backupvault.html#cfn-backup-backupvault-accesspolicy