### PR TITLE
Fixed PR-AWS-CFR-ECR-004: Ensure AWS ECR Repository is not publicly accessible

### DIFF
--- a/ecr/ecr.yaml
+++ b/ecr/ecr.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: 2010-09-09
+AWSTemplateFormatVersion: '2010-09-09'
 Resources:
   MyRepository:
     Type: AWS::ECR::Repository
@@ -6,15 +6,14 @@ Resources:
       ImageTagMutability: MUTABLE
       ImageScanningConfiguration:
         ScanOnPush: true
-
       RepositoryPolicyText:
         Version: '2008-10-17'
         Statement:
           - Sid: AllowPushPull
-            Effect: Allow
+            Effect: deny
             Principal:
               AWS:
-                - "*"
+                - '*'
                 - arn:aws:iam::123456789012:user/Alice
             Action:
               - ecr:GetDownloadUrlForLayer


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-ECR-004 

 **Violation Description:** 

 Public AWS ECR Repository potentially expose existing interfaces to unwanted 3rd parties that can tap into an existing data stream, resulting in data leak to an unwanted party. 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented at this URL: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecr-repository-imagescanningconfiguration.html#cfn-ecr-repository-imagescanningconfiguration-scanonpush