### PR TITLE
Fixed PR-AWS-CFR-SQS-005: Ensure SQS policy documents do not allow all actions

### DIFF
--- a/sqs/sqs.yaml
+++ b/sqs/sqs.yaml
@@ -1,19 +1,19 @@
-AWSTemplateFormatVersion: 2010-09-09
+AWSTemplateFormatVersion: '2010-09-09'
 Resources:
   SampleSQSPolicy:
     Type: AWS::SQS::QueuePolicy
     Properties:
       Queues:
-        - "https://sqs:us-east-2.amazonaws.com/444455556666/queue2"
+        - https://sqs:us-east-2.amazonaws.com/444455556666/queue2
       PolicyDocument:
         Statement:
           - Action:
-              - "SQS:SendMessage"
-              - "SQS:ReceiveMessage"
-              - "*"
-            Effect: "Allow"
-            Resource: "arn:aws:sqs:us-east-2:444455556666:queue2"
+              - SQS:SendMessage
+              - SQS:ReceiveMessage
+              - '*'
+            Effect: Deny
+            Resource: arn:aws:sqs:us-east-2:444455556666:queue2
             Principal:
               AWS:
-                - "111122223333"
-                - "*"
+                - '111122223333'
+                - '*'


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-SQS-005 

 **Violation Description:** 

 This level of access could potentially grant unwanted and unregulated access to anyone given this policy document setting. We recommend you to write a refined policy describing the specific action allowed or required by the specific policy holder 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented at this URL: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sqs-queuepolicy.html#cfn-sqs-queuepolicy-policydocument