### PR TITLE
Fixed PR-AWS-CFR-TRF-001: Ensure Transfer Server is not publicly exposed

### DIFF
--- a/transfer/transfer.json
+++ b/transfer/transfer.json
@@ -16,7 +16,7 @@
                     ],
                     "VpcId": "VpcId"
                 },
-                "EndpointType": "PUBLIC",
+                "EndpointType": "VPC",
                 "LoggingRole": "Logging-Role-ARN",
                 "Protocols": [
                     "SFTP"


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-TRF-001 

 **Violation Description:** 

 It is recommended that you use VPC as the EndpointType. With this endpoint type, you have the option to directly associate up to three Elastic IPv4 addresses (BYO IP included) with your server's endpoint and use VPC security groups to restrict traffic by the client's public IP address. This is not possible with EndpointType set to VPC_ENDPOINT. 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented at this URL: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-transfer-server.html#cfn-transfer-server-endpointdetails