### PR TITLE
Fixed PR-AWS-CFR-VPC-003: Ensure VPC endpoint service is configured for manual acceptance

### DIFF
--- a/vpc/vpc.yaml
+++ b/vpc/vpc.yaml
@@ -1,20 +1,21 @@
-AWSTemplateFormatVersion: 2010-09-09
+AWSTemplateFormatVersion: '2010-09-09'
 Parameters:
   MyVPC:
-    Type: 'AWS::EC2::VPC::Id'
-    Description: Choose which VPC the Application Load Balancer should be deployed to
+    Type: AWS::EC2::VPC::Id
+    Description: Choose which VPC the Application Load Balancer should be deployed
+      to
 Resources:
   mySubnet:
-    Type: 'AWS::EC2::Subnet'
+    Type: AWS::EC2::Subnet
     Properties:
       MapPublicIpOnLaunch: true
-      VpcId: !Ref MyVPC
+      VpcId: !Ref 'MyVPC'
       CidrBlock: 172.31.48.0/20
-      AvailabilityZone: !Select 
+      AvailabilityZone: !Select
         - '0'
-        - !GetAZs 
-          Ref: 'AWS::Region'
-
+        - !GetAZs
+          Ref: AWS::Region
   VPCEndpointService:
     Type: AWS::EC2::VPCEndpointService
-    Properties: {}
+    Properties:
+      AcceptanceRequired: true


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-VPC-003 

 **Violation Description:** 

 AcceptanceRequired Indicates whether requests from service consumers to create an endpoint to your service must be accepted, we recommend you to enable this feature 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented at this URL: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpcendpointservice.html#cfn-ec2-vpcendpointservice-acceptancerequired