### PR TITLE
Fixed PR-AWS-CFR-GLUE-002: Ensure AWS Glue security configuration encryption is enabled

### DIFF
--- a/glue/glue.yaml
+++ b/glue/glue.yaml
@@ -1,16 +1,22 @@
-AWSTemplateFormatVersion: 2010-09-09
+AWSTemplateFormatVersion: '2010-09-09'
 Resources:
   Example:
-    Type: "AWS::Glue::DataCatalogEncryptionSettings"
+    Type: AWS::Glue::DataCatalogEncryptionSettings
     Properties:
       DataCatalogEncryptionSettings:
         ConnectionPasswordEncryption:
-          KmsKeyId: ""
+          KmsKeyId: ''
           ReturnConnectionPasswordEncrypted: false
         EncryptionAtRest:
-          SseAwsKmsKeyId: ""
-
+          SseAwsKmsKeyId: ''
   Example2:
     Type: AWS::Glue::SecurityConfiguration
-    Properties: 
-      Name: "GlueEncryptionConfiguration"
+    Properties:
+      Name: GlueEncryptionConfiguration
+      EncryptionConfiguration:
+        CloudWatchEncryption:
+          CloudWatchEncryptionMode: SSE-KMS
+        JobBookmarksEncryption:
+          JobBookmarksEncryptionMode: SSE-KMS
+        S3Encryptions:
+          S3EncryptionsMode: SSE-KMS


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-GLUE-002 

 **Violation Description:** 

 Ensure AWS Glue security configuration encryption is enabled 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented at this URL: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-securityconfiguration-encryptionconfiguration.html#cfn-glue-securityconfiguration-encryptionconfiguration-s3encryptions