### PR TITLE
Fixed PR-AWS-CFR-WAF-001: JMSAppender in Log4j 1.2 is vulnerable to deserialization of untrusted data when the attacker has write access to the Log4j configuration

### DIFF
--- a/waf/waf.json
+++ b/waf/waf.json
@@ -58,11 +58,7 @@
                             "ManagedRuleGroupStatement": {
                                 "VendorName": "AWS",
                                 "Name": "AWSManagedRulesKnownBadInputsRuleSet",
-                                "ExcludedRules": [
-                                    {
-                                        "Name": "Log4jRCE"
-                                    }
-                                ]
+                                "ExcludedRules": []
                             }
                         }
                     },


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-WAF-001 

 **Violation Description:** 

 Apache Log4j2 2.0-beta9 through 2.12.1 and 2.13.0 through 2.15.0 JNDI features used in configuration, log messages, and parameters do not protect against attacker controlled LDAP and other JNDI related endpoints 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-wafv2-webacl-managedrulegroupstatement.html#cfn-wafv2-webacl-managedrulegroupstatement-name' target='_blank'>here</a>