### PR TITLE
Fixed PR-AWS-CFR-GLUE-001: Ensure Glue Data Catalog encryption is enabled

### DIFF
--- a/glue/glue.yaml
+++ b/glue/glue.yaml
@@ -1,16 +1,16 @@
-AWSTemplateFormatVersion: 2010-09-09
+AWSTemplateFormatVersion: '2010-09-09'
 Resources:
   Example:
-    Type: "AWS::Glue::DataCatalogEncryptionSettings"
+    Type: AWS::Glue::DataCatalogEncryptionSettings
     Properties:
       DataCatalogEncryptionSettings:
         ConnectionPasswordEncryption:
-          KmsKeyId: ""
-          ReturnConnectionPasswordEncrypted: false
+          KmsKeyId: ''
+          ReturnConnectionPasswordEncrypted: true
         EncryptionAtRest:
-          SseAwsKmsKeyId: ""
-
+          SseAwsKmsKeyId: ''
+          CatalogEncryptionMode: SSE-KMS
   Example2:
     Type: AWS::Glue::SecurityConfiguration
-    Properties: 
-      Name: "GlueEncryptionConfiguration"
+    Properties:
+      Name: GlueEncryptionConfiguration


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-GLUE-001 

 **Violation Description:** 

 Ensure that encryption at rest is enabled for your Amazon Glue Data Catalogs in order to meet regulatory requirements and prevent unauthorized users from getting access to sensitive data 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-glue-datacatalogencryptionsettings-encryptionatrest.html' target='_blank'>here</a>