### PR TITLE
Fixed PR-AWS-CFR-MQ-001: AWS MQ is publicly accessible

### DIFF
--- a/mq/mq.yaml
+++ b/mq/mq.yaml
@@ -1,17 +1,16 @@
-AWSTemplateFormatVersion: 2010-09-09
-Description: "Create a basic Amazon MQ for RabbitMQ broker"
-Resources: 
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Create a basic Amazon MQ for RabbitMQ broker
+Resources:
   BasicBroker:
-    Type: "AWS::AmazonMQ::Broker"
-    Properties: 
-      AutoMinorVersionUpgrade: "false"
+    Type: AWS::AmazonMQ::Broker
+    Properties:
+      AutoMinorVersionUpgrade: 'false'
       BrokerName: MyBasicRabbitBroker
       DeploymentMode: SINGLE_INSTANCE
       EngineType: RabbitMQ
-      EngineVersion: "3.8.6"
+      EngineVersion: 3.8.6
       HostInstanceType: mq.t3.micro
-      PubliclyAccessible: "true"
-      Users: 
-        - 
-          Password: AmazonMqPassword            
+      PubliclyAccessible: false
+      Users:
+        - Password: AmazonMqPassword
           Username: AmazonMqUsername


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-MQ-001 

 **Violation Description:** 

 This policy identifies the AWS MQ brokers which are publicly accessible. It is advisable to use MQ brokers privately only from within your AWS Virtual Private Cloud (VPC). Ensure that the AWS MQ brokers provisioned in your AWS account are not publicly accessible from the Internet to avoid sensitive data exposure and minimize security risks. 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-amazonmq-broker.html#cfn-amazonmq-broker-publiclyaccessible' target='_blank'>here</a>