### PR TITLE
Fixed PR-AWS-CFR-VPC-001: AWS VPC subnets should not allow automatic public IP assignment

### DIFF
--- a/vpc/vpc.yaml
+++ b/vpc/vpc.yaml
@@ -1,20 +1,20 @@
-AWSTemplateFormatVersion: 2010-09-09
+AWSTemplateFormatVersion: '2010-09-09'
 Parameters:
   MyVPC:
-    Type: 'AWS::EC2::VPC::Id'
-    Description: Choose which VPC the Application Load Balancer should be deployed to
+    Type: AWS::EC2::VPC::Id
+    Description: Choose which VPC the Application Load Balancer should be deployed
+      to
 Resources:
   mySubnet:
-    Type: 'AWS::EC2::Subnet'
+    Type: AWS::EC2::Subnet
     Properties:
-      MapPublicIpOnLaunch: true
-      VpcId: !Ref MyVPC
+      MapPublicIpOnLaunch: false
+      VpcId: !Ref 'MyVPC'
       CidrBlock: 172.31.48.0/20
-      AvailabilityZone: !Select 
+      AvailabilityZone: !Select
         - '0'
-        - !GetAZs 
-          Ref: 'AWS::Region'
-
+        - !GetAZs
+          Ref: AWS::Region
   VPCEndpointService:
     Type: AWS::EC2::VPCEndpointService
     Properties: {}


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-VPC-001 

 **Violation Description:** 

 This policy identifies VPC subnets which allow automatic public IP assignment. VPC subnet is a part of the VPC having its own rules for traffic. Assigning the Public IP to the subnet automatically (on launch) can accidentally expose the instances within this subnet to internet and should be edited to 'No' post creation of the Subnet. 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-subnet.html' target='_blank'>here</a>