### PR TITLE
Fixed PR-AWS-CFR-EKS-002: AWS EKS unsupported Master node version.

### DIFF
--- a/eks/eks.yaml
+++ b/eks/eks.yaml
@@ -1,23 +1,23 @@
-AWSTemplateFormatVersion: 2010-09-09
+AWSTemplateFormatVersion: '2010-09-09'
 Parameters:
   Subnets:
-    Description: Choose which subnets the Application Load Balancer should be deployed to
-    Type: 'List<AWS::EC2::Subnet::Id>'
+    Description: Choose which subnets the Application Load Balancer should be deployed
+      to
+    Type: List<AWS::EC2::Subnet::Id>
   SecurityGroups:
     Description: Choose which security group you want to apply
-    Type: 'List<AWS::EC2::SecurityGroup::Id>'
+    Type: List<AWS::EC2::SecurityGroup::Id>
   RoleArn:
     Type: String
-    Default: 'arn:aws:iam::155603667260:role/eks-cluster'
+    Default: arn:aws:iam::155603667260:role/eks-cluster
 Resources:
   myCluster:
-    Type: 'AWS::EKS::Cluster'
+    Type: AWS::EKS::Cluster
     Properties:
-      Version: '1.9.1'
       Name: prod
-      RoleArn: !Ref RoleArn
+      RoleArn: !Ref 'RoleArn'
       EndpointPrivateAccess: false
       EndpointPublicAccess: true
       ResourcesVpcConfig:
-        SecurityGroupIds: !Ref SecurityGroups
-        SubnetIds: !Ref Subnets
+        SecurityGroupIds: !Ref 'SecurityGroups'
+        SubnetIds: !Ref 'Subnets'


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-EKS-002 

 **Violation Description:** 

 Ensure your EKS Master node version is supported. This policy checks your EKS master node version and generates an alert if the version running is unsupported. 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-eks-cluster.html#cfn-eks-cluster-version' target='_blank'>here</a>