### PR TITLE
Fixed PR-AWS-CFR-ES-005: AWS Elasticsearch domain has Search slow logs set to disabled

### DIFF
--- a/elasticsearch/elasticsearch.yaml
+++ b/elasticsearch/elasticsearch.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: 2010-09-09
+AWSTemplateFormatVersion: '2010-09-09'
 Parameters:
   InstanceType:
     Description: WebServer EC2 instance type
@@ -49,20 +49,20 @@ Parameters:
       - d2.8xlarge
     ConstraintDescription: must be a valid EC2 instance type.
   LatestAmiId:
-    Type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
     Default: /aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2
   SecurityGroup:
     Description: Select the Security Group to use for the ECS cluster hosts
-    Type: 'List<AWS::EC2::SecurityGroup::Id>'
+    Type: List<AWS::EC2::SecurityGroup::Id>
 Resources:
   EC2Instance:
-    Type: 'AWS::EC2::Instance'
+    Type: AWS::EC2::Instance
     Properties:
-      InstanceType: !Ref InstanceType
-      SecurityGroupIds: !Ref SecurityGroup
-      ImageId: !Ref LatestAmiId
+      InstanceType: !Ref 'InstanceType'
+      SecurityGroupIds: !Ref 'SecurityGroup'
+      ImageId: !Ref 'LatestAmiId'
   ElasticsearchDomain:
-    Type: 'AWS::Elasticsearch::Domain'
+    Type: AWS::Elasticsearch::Domain
     Properties:
       DomainName: test1
       ElasticsearchVersion: '7.10'
@@ -82,14 +82,11 @@ Resources:
         Enabled: true
       LogPublishingOptions:
         ES_APPLICATION_LOGS:
-          CloudWatchLogsLogGroupArn: >-
-            arn:aws:logs:us-east-1:123456789012:log-group:/aws/aes/domains/es-application-logs
+          CloudWatchLogsLogGroupArn: arn:aws:logs:us-east-1:123456789012:log-group:/aws/aes/domains/es-application-logs
           Enabled: false
         SEARCH_SLOW_LOGS:
-          CloudWatchLogsLogGroupArn: >-
-            arn:aws:logs:us-east-1:123456789012:log-group:/aws/aes/domains/es-slow-logs
-          Enabled: false
+          CloudWatchLogsLogGroupArn: arn:aws:logs:us-east-1:123456789012:log-group:/aws/aes/domains/es-slow-logs
+          Enabled: true
         INDEX_SLOW_LOGS:
-          CloudWatchLogsLogGroupArn: >-
-            arn:aws:logs:us-east-1:123456789012:log-group:/aws/aes/domains/es-index-slow-logs
+          CloudWatchLogsLogGroupArn: arn:aws:logs:us-east-1:123456789012:log-group:/aws/aes/domains/es-index-slow-logs
           Enabled: false


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-ES-005 

 **Violation Description:** 

 This policy identifies Elasticsearch domains for which Search slow logs is disabled in your AWS account. Enabling support for publishing Search slow logs to AWS CloudWatch Logs enables you to have full insight into the performance of search operations performed on your Elasticsearch clusters. This will help you in identifying performance issues caused by specific search queries so that you can optimize your queries to address the problem. 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticsearch-domain.html' target='_blank'>here</a>