### PR TITLE
Fixed PR-AWS-CFR-SGM-002: AWS SageMaker notebook instance with root access enabled

### DIFF
--- a/sagemaker/sagemaker.yaml
+++ b/sagemaker/sagemaker.yaml
@@ -6,6 +6,7 @@ Resources:
     Properties:
       InstanceType: ml.t2.large
       RoleArn: !GetAtt 'ExecutionRole.Arn'
+      RootAccess: Disabled
   ExecutionRole:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-SGM-002 

 **Violation Description:** 

 This policy identifies the SageMaker notebook instances which are enabled with root access. Root access means having administrator privileges, users with root access can access and edit all files on the compute instance, including system-critical files. Removing root access prevents notebook users from deleting system-level software, installing new software, and modifying essential environment components.
NOTE: Lifecycle configurations need root access to be able to set up a notebook instance. Because of this, lifecycle configurations associated with a notebook instance always run with root access even if you disable root access for users.

For more details:
https://docs.aws.amazon.com/sagemaker/latest/dg/nbi-root-access.html 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-notebookinstance.html' target='_blank'>here</a>