### PR TITLE
Fixed PR-AWS-CFR-SGM-003: AWS SageMaker notebook instance configured with direct internet access feature

### DIFF
--- a/sagemaker/sagemaker.yaml
+++ b/sagemaker/sagemaker.yaml
@@ -6,6 +6,7 @@ Resources:
     Properties:
       InstanceType: ml.t2.large
       RoleArn: !GetAtt 'ExecutionRole.Arn'
+      DirectInternetAccess: Disabled
   ExecutionRole:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-SGM-003 

 **Violation Description:** 

 This policy identifies SageMaker notebook instances that are configured with direct internet access feature. If AWS SageMaker notebook instances are configured with direct internet access feature, any machine outside the VPC can establish a connection to these instances, which provides an additional avenue for unauthorized access to data and the opportunity for malicious activity.

For more details:
https://docs.aws.amazon.com/sagemaker/latest/dg/appendix-notebook-and-internet-access.html 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sagemaker-notebookinstance.html' target='_blank'>here</a>