### PR TITLE
Fixed PR-AWS-CFR-CB-001: Ensure CodeBuild project Artifact encryption is not disabled

### DIFF
--- a/codebuild/codebuild.json
+++ b/codebuild/codebuild.json
@@ -54,7 +54,7 @@
             "Properties": {
                 "Artifacts": {
                     "Type": "NO_ARTIFACTS",
-                    "EncryptionDisabled": true
+                    "EncryptionDisabled": false
                 },
                 "BadgeEnabled": true,
                 "Environment": {


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-CB-001 

 **Violation Description:** 

 AWS CodeBuild is a fully managed build service in the cloud. CodeBuild compiles your source code, runs unit tests, and produces artifacts that are ready to deploy. Build artifacts, such as a cache, logs, exported raw test report data files, and build results, are encrypted by default using CMKs for Amazon S3 that are managed by the AWS Key Management Service. If you do not want to use these CMKs, you must create and configure a customer-managed CMK. 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-codebuild-project-artifacts.html#cfn-codebuild-project-artifacts-encryptiondisabled' target='_blank'>here</a>