### PR TITLE
Fixed PR-AWS-CFR-ELB-004: AWS Elastic Load Balancer (Classic) with connection draining disabled

### DIFF
--- a/auto_scale/autoscale.yaml
+++ b/auto_scale/autoscale.yaml
@@ -2,8 +2,8 @@ AWSTemplateFormatVersion: '2010-09-09'
 Parameters:
   LatestAmiId:
     Description: Region specific image from the Parameter Store
-    Type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
-    Default: '/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2'
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: /aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2
   myLaunchTemplateVersionNumber:
     Type: String
   Subnets:
@@ -11,11 +11,11 @@ Parameters:
 Resources:
   myLaunchTemplate:
     Type: AWS::EC2::LaunchTemplate
-    Properties: 
-      LaunchTemplateData: 
-        CreditSpecification: 
+    Properties:
+      LaunchTemplateData:
+        CreditSpecification:
           CpuCredits: Unlimited
-        ImageId: !Ref LatestAmiId
+        ImageId: !Ref 'LatestAmiId'
         InstanceType: t2.micro
   myASG:
     Type: AWS::AutoScaling::AutoScalingGroup
@@ -24,14 +24,13 @@ Resources:
       MaxSize: '1'
       DesiredCapacity: '1'
       LaunchTemplate:
-        LaunchTemplateId: !Ref myLaunchTemplate
-        Version: !Ref myLaunchTemplateVersionNumber
-      VPCZoneIdentifier: !Ref Subnets
+        LaunchTemplateId: !Ref 'myLaunchTemplate'
+        Version: !Ref 'myLaunchTemplateVersionNumber'
+      VPCZoneIdentifier: !Ref 'Subnets'
       HealthCheckType: ELB
       HealthCheckGracePeriod: 300
       LoadBalancerNames:
-      - !Ref ElasticLoadBalancer
-
+        - !Ref 'ElasticLoadBalancer'
   ElasticLoadBalancer:
     Type: AWS::ElasticLoadBalancing::LoadBalancer
     Properties:
@@ -47,3 +46,5 @@ Resources:
         UnhealthyThreshold: '5'
         Interval: '30'
         Timeout: '5'
+      ConnectionDrainingPolicy:
+        Enabled: true


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-ELB-004 

 **Violation Description:** 

 This policy identifies Classic Elastic Load Balancers which have connection draining disabled. Connection Draining feature ensures that a Classic load balancer stops sending requests to instances that are de-registering or unhealthy, while keeping the existing connections open. This enables the load balancer to complete in-flight requests made to instances that are de-registering or unhealthy. 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-elb.html' target='_blank'>here</a>