### PR TITLE
Fixed PR-AWS-CFR-S3-002: AWS S3 Bucket has Global DELETE Permissions enabled via bucket policy

### DIFF
--- a/s3/deploy.yaml
+++ b/s3/deploy.yaml
@@ -1,16 +1,15 @@
-AWSTemplateFormatVersion: 2010-09-09
+AWSTemplateFormatVersion: '2010-09-09'
 Metadata:
   License: Apache-2.0
 Description: >-
-  AWS CloudFormation Sample Template S3_Website_Bucket_With_Retain_On_Delete:
-  Sample template showing how to create a publicly accessible S3 bucket
-  configured for website access with a deletion policy of retain on delete.
-  **WARNING** This template creates an S3 bucket that will NOT be deleted when
-  the stack is deleted. You will be billed for the AWS resources used if you
-  create a stack from this template.
+  AWS CloudFormation Sample Template S3_Website_Bucket_With_Retain_On_Delete: Sample
+  template showing how to create a publicly accessible S3 bucket configured for website
+  access with a deletion policy of retain on delete. **WARNING** This template creates
+  an S3 bucket that will NOT be deleted when the stack is deleted. You will be billed
+  for the AWS resources used if you create a stack from this template.
 Resources:
   S3Bucket:
-    Type: 'AWS::S3::Bucket'
+    Type: AWS::S3::Bucket
     Properties:
       AccessControl: PublicRead
       WebsiteConfiguration:
@@ -18,45 +17,41 @@ Resources:
         ErrorDocument: error.html
     DeletionPolicy: Retain
   S3BUCKETPOL:
-    Type: 'AWS::S3::BucketPolicy'
+    Type: AWS::S3::BucketPolicy
     Properties:
-      Bucket: !Ref S3BUCKET
+      Bucket: !Ref 'S3BUCKET'
       PolicyDocument:
         Id: CrossAccessPolicy
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Sid: CrossAccPolicyDoc
             Action:
-              - 's3:GetObject'
+              - s3:GetObject
             Effect: Allow
             Resource: !Sub 'arn:aws:s3:::${S3BUCKET}/*'
             Principal: '*'
           - Sid: HttpsOnly
             Action:
-              - 's3:DeleteObject'
-            Effect: Allow
+              - s3:DeleteObject
+            Effect: Deny
             Resource: !Sub 'arn:aws:s3:::${BucketName}/*'
             Principal: '*'
             Condition:
               StringLike:
-                'aws:SecureTransport': false
+                aws:SecureTransport: false
           - Sid: IPAllow
             Action:
-              - 's3:PutObject'
+              - s3:PutObject
             Effect: Allow
             Resource: !Sub 'arn:aws:s3:::${BucketName}/*'
             Principal: '*'
 Outputs:
   WebsiteURL:
-    Value: !GetAtt 
-      - S3Bucket
-      - WebsiteURL
+    Value: !GetAtt 'S3Bucket.WebsiteURL'
     Description: URL for website hosted on S3
   S3BucketSecureURL:
-    Value: !Join 
+    Value: !Join
       - ''
-      - - 'https://'
-        - !GetAtt 
-          - S3Bucket
-          - DomainName
+      - - https://
+        - !GetAtt 'S3Bucket.DomainName'
     Description: Name of S3 bucket to hold website content


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-S3-002 

 **Violation Description:** 

 This policy identifies the S3 Bucket(s) which will allow any unauthenticated user to DELETE objects from a bucket. These permissions permit anyone, malicious or not, to DELETE objects from your S3 bucket if they can guess the namespace. Since the S3 service does not protect the namespace other than with ACLs and Bucket Policy, you risk loss or compromise of critical data by leaving this open. 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html' target='_blank'>here</a>