### PR TITLE
Fixed PR-AWS-CFR-S3-016: Ensure S3 bucket has enabled lock configuration

### DIFF
--- a/codebuild/codebuild.json
+++ b/codebuild/codebuild.json
@@ -46,7 +46,8 @@
                             "Status": "Enabled"
                         }
                     ]
-                }
+                },
+                "ObjectLockEnabled": true
             },
             "Type": "AWS::S3::Bucket"
         },


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-S3-016 

 **Violation Description:** 

 Indicates whether this bucket has an Object Lock configuration enabled. Enable ObjectLockEnabled when you apply ObjectLockConfiguration to a bucket. 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-objectlockenabled' target='_blank'>here</a>