### PR TITLE
Fixed PR-AWS-CFR-S3-018: Ensure S3 Bucket has public access blocks

### DIFF
--- a/codebuild/codebuild.json
+++ b/codebuild/codebuild.json
@@ -46,6 +46,9 @@
                             "Status": "Enabled"
                         }
                     ]
+                },
+                "PublicAccessBlockConfiguration": {
+                    "BlockPublicAcls": true
                 }
             },
             "Type": "AWS::S3::Bucket"


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-S3-018 

 **Violation Description:** 

 We recommend you ensure S3 bucket has public access blocks. If the public access block is not attached it defaults to False 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-publicaccessblockconfiguration.html#cfn-s3-bucket-publicaccessblockconfiguration-blockpublicpolicy' target='_blank'>here</a>