### PR TITLE
Fixed PR-AWS-CFR-S3-019: Ensure S3 bucket RestrictPublicBucket is enabled

### DIFF
--- a/codepipeline/codepipeline.yaml
+++ b/codepipeline/codepipeline.yaml
@@ -1,133 +1,112 @@
 AWSTemplateFormatVersion: '2010-09-09'
-# *** Change this to something useful for you!
 Description: github-codepipeline
-
 Parameters:
-  # *** This value must always be passed in when creating / updating stack
-  # "NoEcho" is set to true, for security, so token won't be visible when examining the resulting stack
   GitHubOAuthToken:
     Type: String
     NoEcho: true
     AllowedPattern: '[a-z0-9A-Z_]*'
-
-  # *** The remaining parameters should either be:
-  # - overridden via changing "Default" here (PREFERABLE, since then they're in source control)
-  # - or you can pass them in when creating / updating the stack
-  
-  # *** The owner of the Github repo for this application.
   GitHubOwner:
     Type: String
     Default: symphoniacloud
-    AllowedPattern: "[A-Za-z0-9-]+"
-
+    AllowedPattern: '[A-Za-z0-9-]+'
   GitHubRepo:
     Type: String
     Default: github-codepipeline
-    AllowedPattern: "[A-Za-z0-9-]+"
-
+    AllowedPattern: '[A-Za-z0-9-]+'
   GitHubBranch:
     Type: String
     Default: master
-    AllowedPattern: "[A-Za-z0-9-]+"
-
-  # *** The stack name for the actual application we're deploying
+    AllowedPattern: '[A-Za-z0-9-]+'
   ApplicationStackName:
     Type: String
     Default: github-codepipeline-app
-    AllowedPattern: "[A-Za-z0-9-]+"
-
+    AllowedPattern: '[A-Za-z0-9-]+'
 Resources:
   PipelineArtifactsBucket:
     Type: AWS::S3::Bucket
     Properties:
       VersioningConfiguration:
         Status: Enabled
-
+      PublicAccessBlockConfiguration:
+        RestrictPublicBuckets: true
   CodePipeline:
     Type: AWS::CodePipeline::Pipeline
     Properties:
       ArtifactStore:
         Type: S3
-        Location: !Ref PipelineArtifactsBucket
+        Location: !Ref 'PipelineArtifactsBucket'
       RestartExecutionOnUpdate: true
-      RoleArn: !GetAtt CodePipelineRole.Arn
+      RoleArn: !GetAtt 'CodePipelineRole.Arn'
       Stages:
-      - Name: Source
-        Actions:
         - Name: Source
-          InputArtifacts: []
-          ActionTypeId:
-            Category: Source
-            Owner: ThirdParty
-            Version: 1
-            Provider: GitHub
-          OutputArtifacts:
-          - Name: SourceCode
-          Configuration:
-            Owner: !Ref GitHubOwner
-            Repo: !Ref GitHubRepo
-            Branch: !Ref GitHubBranch
-            PollForSourceChanges: false
-            OAuthToken: !Ref GitHubOAuthToken
-          RunOrder: 1
-      # Build and Deploy, etc., stages would follow. Here is an example
-      - Name: Deploy
-        Actions:
-        - Name: CloudFormationDeploy
-          ActionTypeId:
-            Category: Deploy
-            Owner: AWS
-            Provider: CloudFormation
-            Version: '1'
-          InputArtifacts:
-            - Name: SourceCode
-          Configuration:
-            ActionMode: CREATE_UPDATE
-            Capabilities: CAPABILITY_IAM
-            RoleArn: !GetAtt CloudformationRole.Arn
-            StackName: !Ref ApplicationStackName
-            TemplatePath: !Sub "SourceCode::application.yaml"
-          RunOrder: 1
-
-  # 'GithubWebhook' satisfies two requirements:
-  # -- Means that updates are pushed from GitHub, rather than AWS having to poll
-  # -- Means we can filter for required changes
+          Actions:
+            - Name: Source
+              InputArtifacts: []
+              ActionTypeId:
+                Category: Source
+                Owner: ThirdParty
+                Version: 1
+                Provider: GitHub
+              OutputArtifacts:
+                - Name: SourceCode
+              Configuration:
+                Owner: !Ref 'GitHubOwner'
+                Repo: !Ref 'GitHubRepo'
+                Branch: !Ref 'GitHubBranch'
+                PollForSourceChanges: false
+                OAuthToken: !Ref 'GitHubOAuthToken'
+              RunOrder: 1
+        - Name: Deploy
+          Actions:
+            - Name: CloudFormationDeploy
+              ActionTypeId:
+                Category: Deploy
+                Owner: AWS
+                Provider: CloudFormation
+                Version: '1'
+              InputArtifacts:
+                - Name: SourceCode
+              Configuration:
+                ActionMode: CREATE_UPDATE
+                Capabilities: CAPABILITY_IAM
+                RoleArn: !GetAtt 'CloudformationRole.Arn'
+                StackName: !Ref 'ApplicationStackName'
+                TemplatePath: !Sub 'SourceCode::application.yaml'
+              RunOrder: 1
   GithubWebhook:
-    Type: 'AWS::CodePipeline::Webhook'
+    Type: AWS::CodePipeline::Webhook
     Properties:
       Authentication: GITHUB_HMAC
       AuthenticationConfiguration:
-        SecretToken: !Ref GitHubOAuthToken
+        SecretToken: !Ref 'GitHubOAuthToken'
       RegisterWithThirdParty: 'true'
       Filters:
-      - JsonPath: "$.ref"
-        MatchEquals: refs/heads/{Branch}
-      TargetPipeline: !Ref CodePipeline
+        - JsonPath: $.ref
+          MatchEquals: refs/heads/{Branch}
+      TargetPipeline: !Ref 'CodePipeline'
       TargetAction: Source
-      TargetPipelineVersion: !GetAtt CodePipeline.Version
-
+      TargetPipelineVersion: !GetAtt 'CodePipeline.Version'
   CodePipelineRole:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: "2012-10-17"
+        Version: '2012-10-17'
         Statement:
-        - Effect: Allow
-          Principal:
-            Service: codepipeline.amazonaws.com
-          Action: sts:AssumeRole
+          - Effect: Allow
+            Principal:
+              Service: codepipeline.amazonaws.com
+            Action: sts:AssumeRole
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/AdministratorAccess #TODO: Reduce permissions
-
+        - arn:aws:iam::aws:policy/AdministratorAccess
   CloudformationRole:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: "2012-10-17"
+        Version: '2012-10-17'
         Statement:
-        - Effect: Allow
-          Principal:
-            Service: cloudformation.amazonaws.com
-          Action: sts:AssumeRole
+          - Effect: Allow
+            Principal:
+              Service: cloudformation.amazonaws.com
+            Action: sts:AssumeRole
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/AdministratorAccess #TODO: Reduce permissions
+        - arn:aws:iam::aws:policy/AdministratorAccess


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-S3-019 

 **Violation Description:** 

 Enabling this setting does not affect previously stored bucket policies. Public and cross-account access within any public bucket policy, including non-public delegation to specific accounts, is blocked 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-publicaccessblockconfiguration.html#cfn-s3-bucket-publicaccessblockconfiguration-restrictpublicbuckets' target='_blank'>here</a>