### PR TITLE
Fixed PR-AWS-CFR-S3-019: Ensure S3 bucket RestrictPublicBucket is enabled

### DIFF
--- a/codebuild/codebuild.json
+++ b/codebuild/codebuild.json
@@ -46,6 +46,9 @@
                             "Status": "Enabled"
                         }
                     ]
+                },
+                "PublicAccessBlockConfiguration": {
+                    "RestrictPublicBuckets": true
                 }
             },
             "Type": "AWS::S3::Bucket"


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-S3-019 

 **Violation Description:** 

 Enabling this setting does not affect previously stored bucket policies. Public and cross-account access within any public bucket policy, including non-public delegation to specific accounts, is blocked 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-publicaccessblockconfiguration.html#cfn-s3-bucket-publicaccessblockconfiguration-restrictpublicbuckets' target='_blank'>here</a>