### PR TITLE
Fixed PR-AWS-CFR-S3-020: Ensure S3 bucket IgnorePublicAcls is enabled

### DIFF
--- a/elb/elb.yaml
+++ b/elb/elb.yaml
@@ -1,27 +1,31 @@
-AWSTemplateFormatVersion: 2010-09-09
+AWSTemplateFormatVersion: '2010-09-09'
 Description: Elastic Load Balancer
 Parameters:
   VPC:
-    Type: 'AWS::EC2::VPC::Id'
-    Description: Choose which VPC the Application Load Balancer should be deployed to
+    Type: AWS::EC2::VPC::Id
+    Description: Choose which VPC the Application Load Balancer should be deployed
+      to
   Subnets:
-    Description: Choose which subnets the Application Load Balancer should be deployed to
-    Type: 'List<AWS::EC2::Subnet::Id>'
+    Description: Choose which subnets the Application Load Balancer should be deployed
+      to
+    Type: List<AWS::EC2::Subnet::Id>
 Resources:
   S3BUCKET:
-    Type: 'AWS::S3::Bucket'
+    Type: AWS::S3::Bucket
     DeletionPolicy: Retain
     Properties:
       VersioningConfiguration:
         Status: Enabled
+      PublicAccessBlockConfiguration:
+        IgnorePublicAcls: true
   MyLoadBalancer:
-    Type: 'AWS::ElasticLoadBalancing::LoadBalancer'
+    Type: AWS::ElasticLoadBalancing::LoadBalancer
     Properties:
       AccessLoggingPolicy:
         Enabled: false
-        S3BucketName: !Ref S3BUCKET
+        S3BucketName: !Ref 'S3BUCKET'
       CrossZone: false
-      Subnets: !Ref Subnets
+      Subnets: !Ref 'Subnets'
       ConnectionDrainingPolicy:
         Enabled: false
       Listeners:
@@ -31,7 +35,7 @@ Resources:
           Protocol: HTTPS
           PolicyNames:
             - My-SSLNegotiation-Policy
-          SSLCertificateId: 'arn:aws:iam::123456789012:server-certificate/my-server-certificate'
+          SSLCertificateId: arn:aws:iam::123456789012:server-certificate/my-server-certificate
       Policies:
         - PolicyName: My-SSLNegotiation-Policy
           PolicyType: SSLNegotiationPolicyType
@@ -183,40 +187,40 @@ Resources:
             - Name: Protocol-TLSv1.1
               Value: 'true'
   MyLoadBalancerV2:
-    Type: 'AWS::ElasticLoadBalancingV2::LoadBalancer'
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
       LoadBalancerAttributes:
         - Key: access_logs.s3.enabled
           Value: false
-      Subnets: !Ref Subnets
+      Subnets: !Ref 'Subnets'
   DummyTargetGroupPublic:
-    Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
       HealthCheckIntervalSeconds: 6
       HealthCheckPath: /
       HealthCheckProtocol: HTTP
       HealthCheckTimeoutSeconds: 5
       HealthyThresholdCount: 2
-      Name: !Join 
+      Name: !Join
         - '-'
         - - !Ref 'AWS::StackName'
           - drop-1
       Port: 80
       Protocol: HTTP
       UnhealthyThresholdCount: 2
-      VpcId: !Ref VPC
+      VpcId: !Ref 'VPC'
   PublicLoadBalancerListener:
-    Type: 'AWS::ElasticLoadBalancingV2::Listener'
+    Type: AWS::ElasticLoadBalancingV2::Listener
     DependsOn:
       - MyLoadBalancerV2
     Properties:
       DefaultActions:
-        - TargetGroupArn: !Ref DummyTargetGroupPublic
+        - TargetGroupArn: !Ref 'DummyTargetGroupPublic'
           Type: redirect
           RedirectConfig:
             Protocol: http
-        - TargetGroupArn: !Ref DummyTargetGroupPublic
+        - TargetGroupArn: !Ref 'DummyTargetGroupPublic'
           Type: authenticate-cognito
-      LoadBalancerArn: !Ref MyLoadBalancerV2
+      LoadBalancerArn: !Ref 'MyLoadBalancerV2'
       Port: 80
       Protocol: HTTP


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-S3-020 

 **Violation Description:** 

 This will block public access granted by ACLs while still allowing PUT Object calls that include a public ACL 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-publicaccessblockconfiguration.html#cfn-s3-bucket-publicaccessblockconfiguration-ignorepublicacls' target='_blank'>here</a>