### PR TITLE
Fixed PR-AWS-CFR-S3-020: Ensure S3 bucket IgnorePublicAcls is enabled

### DIFF
--- a/codebuild/codebuild.json
+++ b/codebuild/codebuild.json
@@ -46,6 +46,9 @@
                             "Status": "Enabled"
                         }
                     ]
+                },
+                "PublicAccessBlockConfiguration": {
+                    "IgnorePublicAcls": true
                 }
             },
             "Type": "AWS::S3::Bucket"


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-S3-020 

 **Violation Description:** 

 This will block public access granted by ACLs while still allowing PUT Object calls that include a public ACL 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-publicaccessblockconfiguration.html#cfn-s3-bucket-publicaccessblockconfiguration-ignorepublicacls' target='_blank'>here</a>