### PR TITLE
Fixed PR-AWS-CFR-S3-021: Ensure S3 Bucket BlockPublicPolicy is enabled

### DIFF
--- a/codebuild/codebuild.json
+++ b/codebuild/codebuild.json
@@ -46,6 +46,9 @@
                             "Status": "Enabled"
                         }
                     ]
+                },
+                "PublicAccessBlockConfiguration": {
+                    "BlockPublicPolicy": true
                 }
             },
             "Type": "AWS::S3::Bucket"


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-S3-021 

 **Violation Description:** 

 If an AWS account is used to host a data lake or another business application, blocking public access will serve as an account-level guard against accidental public exposure. 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-publicaccessblockconfiguration.html#cfn-s3-bucket-publicaccessblockconfiguration-blockpublicpolicy' target='_blank'>here</a>