### PR TITLE
Fixed PR-AWS-CFR-S3-021: Ensure S3 Bucket BlockPublicPolicy is enabled

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,59 +1,60 @@
-AWSTemplateFormatVersion: 2010-09-09
+AWSTemplateFormatVersion: '2010-09-09'
 Metadata:
   License: Apache-2.0
 Description: >-
-  AWS CloudFormation Sample Template Config: This template demonstrates the
-  usage of AWS Config resources. **WARNING** You will be billed for the AWS
-  resources used if you create a stack from this template.
+  AWS CloudFormation Sample Template Config: This template demonstrates the usage
+  of AWS Config resources. **WARNING** You will be billed for the AWS resources used
+  if you create a stack from this template.
 Resources:
   ConfigRecorder:
-    Type: 'AWS::Config::ConfigurationRecorder'
+    Type: AWS::Config::ConfigurationRecorder
     Properties:
       Name: MyConfigRecorder
       RecordingGroup:
         ResourceTypes: []
-      RoleARN: !GetAtt
-        - ConfigRole
-        - Arn
+      RoleARN: !GetAtt 'ConfigRole.Arn'
   ConfigBucket:
-    Type: 'AWS::S3::Bucket'
+    Type: AWS::S3::Bucket
+    Properties:
+      PublicAccessBlockConfiguration:
+        BlockPublicPolicy: true
   ConfigRole:
-    Type: 'AWS::IAM::Role'
+    Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
               Service:
                 - config.amazonaws.com
             Action:
-              - 'sts:AssumeRole'
+              - sts:AssumeRole
       ManagedPolicyArns:
-        - 'arn:aws:iam::aws:policy/service-role/AWSConfigRole'
+        - arn:aws:iam::aws:policy/service-role/AWSConfigRole
       Policies:
         - PolicyName: root
           PolicyDocument:
-            Version: 2012-10-17
+            Version: '2012-10-17'
             Statement:
               - Effect: Allow
-                Action: 's3:GetBucketAcl'
-                Resource: !Join 
+                Action: s3:GetBucketAcl
+                Resource: !Join
                   - ''
                   - - 'arn:aws:s3:::'
-                    - !Ref ConfigBucket
+                    - !Ref 'ConfigBucket'
               - Effect: Allow
-                Action: 's3:PutObject'
-                Resource: !Join 
+                Action: s3:PutObject
+                Resource: !Join
                   - ''
                   - - 'arn:aws:s3:::'
-                    - !Ref ConfigBucket
+                    - !Ref 'ConfigBucket'
                     - /AWSLogs/
                     - !Ref 'AWS::AccountId'
                     - /*
                 Condition:
                   StringEquals:
-                    's3:x-amz-acl': bucket-owner-full-control
+                    s3:x-amz-acl: bucket-owner-full-control
               - Effect: Allow
-                Action: 'config:Put*'
+                Action: config:Put*
                 Resource: '*'


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-S3-021 

 **Violation Description:** 

 If an AWS account is used to host a data lake or another business application, blocking public access will serve as an account-level guard against accidental public exposure. 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-publicaccessblockconfiguration.html#cfn-s3-bucket-publicaccessblockconfiguration-blockpublicpolicy' target='_blank'>here</a>