### PR TITLE
Fixed PR-AWS-CFR-EMR-007: AWS EMR cluster is not enabled with data encryption in transit

### DIFF
--- a/emr/emr.yaml
+++ b/emr/emr.yaml
@@ -1,8 +1,8 @@
-AWSTemplateFormatVersion: 2010-09-09
+AWSTemplateFormatVersion: '2010-09-09'
 Conditions:
-  WithSpotPrice: !Not 
-    - !Equals 
-      - !Ref SpotPrice
+  WithSpotPrice: !Not
+    - !Equals
+      - !Ref 'SpotPrice'
       - '0'
 Description: Sample CloudFormation template for creating an EMR cluster
 Parameters:
@@ -16,31 +16,31 @@ Parameters:
     Type: Number
   Subnet:
     Description: Subnet ID for creating the EMR cluster
-    Type: 'AWS::EC2::Subnet::Id'
+    Type: AWS::EC2::Subnet::Id
 Resources:
   EMRInstanceProfile:
     Properties:
       Roles:
-        - !Ref EMRJobFlowRole
-    Type: 'AWS::IAM::InstanceProfile'
+        - !Ref 'EMRJobFlowRole'
+    Type: AWS::IAM::InstanceProfile
     Metadata:
-      'AWS::CloudFormation::Designer':
+      AWS::CloudFormation::Designer:
         id: 4ce96dbe-d564-4f30-a44e-a0e7f6e46690
   EMRJobFlowRole:
     Properties:
       AssumeRolePolicyDocument:
         Statement:
           - Action:
-              - 'sts:AssumeRole'
+              - sts:AssumeRole
             Effect: Allow
             Principal:
               Service:
                 - ec2.amazonaws.com
       ManagedPolicyArns:
-        - 'arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceforEC2Role'
-    Type: 'AWS::IAM::Role'
+        - arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceforEC2Role
+    Type: AWS::IAM::Role
     Metadata:
-      'AWS::CloudFormation::Designer':
+      AWS::CloudFormation::Designer:
         id: 7935bef0-f0ed-4ee1-826b-75b2baadba34
   EMRSampleCluster:
     Properties:
@@ -55,7 +55,7 @@ Resources:
             Args:
               - dummy
               - parameter
-            Path: 'file:/usr/share/aws/emr/scripts/install-hue'
+            Path: file:/usr/share/aws/emr/scripts/install-hue
       Configurations:
         - Classification: core-site
           ConfigurationProperties:
@@ -70,10 +70,10 @@ Resources:
             - Classification: export
               ConfigurationProperties:
                 HADOOP_DATANODE_HEAPSIZE: '2048'
-                HADOOP_NAMENODE_OPTS: !Join 
+                HADOOP_NAMENODE_OPTS: !Join
                   - ''
-                  - - '-XX:GCTimeRatio='
-                    - !Ref GcTimeRatioValue
+                  - - -XX:GCTimeRatio=
+                    - !Ref 'GcTimeRatioValue'
       Instances:
         MasterInstanceGroup:
           InstanceCount: 1
@@ -107,9 +107,9 @@ Resources:
                     Statistic: AVERAGE
                     Threshold: '50'
                     Unit: PERCENT
-          BidPrice: !If 
+          BidPrice: !If
             - WithSpotPrice
-            - !Ref SpotPrice
+            - !Ref 'SpotPrice'
             - !Ref 'AWS::NoValue'
           EbsConfiguration:
             EbsBlockDeviceConfigs:
@@ -120,25 +120,25 @@ Resources:
             EbsOptimized: true
           InstanceCount: '1'
           InstanceType: m4.large
-          Market: !If 
+          Market: !If
             - WithSpotPrice
             - SPOT
             - ON_DEMAND
           Name: Core Instance
-        Ec2SubnetId: !Ref Subnet
-      JobFlowRole: !Ref EMRInstanceProfile
+        Ec2SubnetId: !Ref 'Subnet'
+      JobFlowRole: !Ref 'EMRInstanceProfile'
       Name: EMR Sample Cluster
       ReleaseLabel: emr-6.3.0
-      SecurityConfiguration: !Ref EMRSecurityConfiguration
-      ServiceRole: !Ref EMRServiceRole
+      SecurityConfiguration: !Ref 'EMRSecurityConfiguration'
+      ServiceRole: !Ref 'EMRServiceRole'
       Tags:
         - Key: Name
           Value: EMR Sample Cluster
       VisibleToAllUsers: true
-      AutoScalingRole: 'EMR_AutoScaling_DefaultRole'
-    Type: 'AWS::EMR::Cluster'
+      AutoScalingRole: EMR_AutoScaling_DefaultRole
+    Type: AWS::EMR::Cluster
     Metadata:
-      'AWS::CloudFormation::Designer':
+      AWS::CloudFormation::Designer:
         id: e94a5475-45f5-44f6-80e8-0d3fb38f6bfd
   EMRSecurityConfiguration:
     Properties:
@@ -147,36 +147,36 @@ Resources:
         EncryptionConfiguration:
           AtRestEncryptionConfiguration:
             LocalDiskEncryptionConfiguration:
-              AwsKmsKey: 'arn:aws:kms:us-east-1:123456789012:key/1234-1234-1234-1234-1234'
+              AwsKmsKey: arn:aws:kms:us-east-1:123456789012:key/1234-1234-1234-1234-1234
               EncryptionKeyProviderType: AwsKms
             S3EncryptionConfiguration:
-              AwsKmsKey: 'arn:aws:kms:us-east-1:123456789012:key/1234-1234-1234-1234-1234'
+              AwsKmsKey: arn:aws:kms:us-east-1:123456789012:key/1234-1234-1234-1234-1234
               EncryptionMode: SSE-KMS
           EnableAtRestEncryption: false
-          EnableInTransitEncryption: false
+          EnableInTransitEncryption: true
           InTransitEncryptionConfiguration:
             TLSCertificateConfiguration:
               CertificateProviderType: PEM
-              S3Object: 's3://MyConfigStore/artifacts/MyCerts.zip'
-    Type: 'AWS::EMR::SecurityConfiguration'
+              S3Object: s3://MyConfigStore/artifacts/MyCerts.zip
+    Type: AWS::EMR::SecurityConfiguration
     Metadata:
-      'AWS::CloudFormation::Designer':
+      AWS::CloudFormation::Designer:
         id: 400d803c-fd1e-4a9e-92e9-4bb90f23831b
   EMRServiceRole:
     Properties:
       AssumeRolePolicyDocument:
         Statement:
           - Action:
-              - 'sts:AssumeRole'
+              - sts:AssumeRole
             Effect: Allow
             Principal:
               Service:
                 - elasticmapreduce.amazonaws.com
       ManagedPolicyArns:
-        - 'arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceRole'
-    Type: 'AWS::IAM::Role'
+        - arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceRole
+    Type: AWS::IAM::Role
     Metadata:
-      'AWS::CloudFormation::Designer':
+      AWS::CloudFormation::Designer:
         id: 487939b2-57e4-4bfd-bb48-b361400d29ae
   TestStep:
     Properties:
@@ -185,26 +185,26 @@ Resources:
         Args:
           - '5'
           - '10'
-        Jar: 's3://emr-cfn-test/hadoop-mapreduce-examples-2.6.0.jar'
+        Jar: s3://emr-cfn-test/hadoop-mapreduce-examples-2.6.0.jar
         MainClass: pi
         StepProperties:
           - Key: my.custom.property
             Value: my.custom.value
       Name: TestStep
-      VpcId: !Ref EMRSampleCluster
-    Type: 'AWS::EMR::Step'
+      VpcId: !Ref 'EMRSampleCluster'
+    Type: AWS::EMR::Step
     Metadata:
-      'AWS::CloudFormation::Designer':
+      AWS::CloudFormation::Designer:
         id: 3cea84fe-dd19-4f81-a096-11f383b7a893
 Metadata:
-  'AWS::CloudFormation::Designer':
+  AWS::CloudFormation::Designer:
     487939b2-57e4-4bfd-bb48-b361400d29ae:
       size:
         width: 60
         height: 60
       position:
         x: 190
-        'y': 120
+        y: 120
       z: 1
       embeds: []
     400d803c-fd1e-4a9e-92e9-4bb90f23831b:
@@ -213,7 +213,7 @@ Metadata:
         height: 60
       position:
         x: 430
-        'y': 120
+        y: 120
       z: 1
       embeds: []
     7935bef0-f0ed-4ee1-826b-75b2baadba34:
@@ -222,7 +222,7 @@ Metadata:
         height: 60
       position:
         x: 60
-        'y': 230
+        y: 230
       z: 1
       embeds: []
     4ce96dbe-d564-4f30-a44e-a0e7f6e46690:
@@ -231,7 +231,7 @@ Metadata:
         height: 60
       position:
         x: 320
-        'y': 230
+        y: 230
       z: 1
       embeds: []
       isassociatedwith:
@@ -242,7 +242,7 @@ Metadata:
         height: 60
       position:
         x: 320
-        'y': 120
+        y: 120
       z: 1
       embeds: []
     3cea84fe-dd19-4f81-a096-11f383b7a893:
@@ -251,7 +251,7 @@ Metadata:
         height: 60
       position:
         x: 320
-        'y': 0
+        y: 0
       z: 0
       embeds: []
       iscontainedinside:


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-EMR-007 

 **Violation Description:** 

 This policy identifies AWS EMR clusters which are not enabled with data encryption in transit. It is highly recommended to implement in-transit encryption in order to protect data from unauthorized access as it travels through the network, between clients and storage server. Enabling data encryption in-transit helps prevent unauthorized users from reading sensitive data between your EMR clusters and their associated storage systems. 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticmapreduce-cluster.html#cfn-elasticmapreduce-cluster-securityconfiguration' target='_blank'>here</a>