### PR TITLE
Fixed PR-AWS-CFR-SQS-004: Ensure SQS queue policy is not publicly accessible

### DIFF
--- a/sqs/sqs.yaml
+++ b/sqs/sqs.yaml
@@ -1,19 +1,19 @@
-AWSTemplateFormatVersion: 2010-09-09
+AWSTemplateFormatVersion: '2010-09-09'
 Resources:
   SampleSQSPolicy:
     Type: AWS::SQS::QueuePolicy
     Properties:
       Queues:
-        - "https://sqs:us-east-2.amazonaws.com/444455556666/queue2"
+        - https://sqs:us-east-2.amazonaws.com/444455556666/queue2
       PolicyDocument:
         Statement:
           - Action:
-              - "SQS:SendMessage"
-              - "SQS:ReceiveMessage"
-              - "*"
-            Effect: "Allow"
-            Resource: "arn:aws:sqs:us-east-2:444455556666:queue2"
+              - SQS:SendMessage
+              - SQS:ReceiveMessage
+              - '*'
+            Effect: Deny
+            Resource: arn:aws:sqs:us-east-2:444455556666:queue2
             Principal:
               AWS:
-                - "111122223333"
-                - "*"
+                - '111122223333'
+                - '*'


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-SQS-004 

 **Violation Description:** 

 Public SQS queues potentially expose existing interfaces to unwanted 3rd parties that can tap into an existing data stream, resulting in data leak to an unwanted party. 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sqs-queuepolicy.html#cfn-sqs-queuepolicy-policydocument' target='_blank'>here</a>