### PR TITLE
Fixed PR-AWS-CFR-MSK-003: Ensure client authentication is enabled with TLS (mutual TLS authentication)

### DIFF
--- a/msk/msk.yaml
+++ b/msk/msk.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: 2010-09-09
+AWSTemplateFormatVersion: '2010-09-09'
 Description: MSK Cluster with all properties
 Parameters:
   SubnetIds:
@@ -7,7 +7,7 @@ Parameters:
     Type: List<AWS::EC2::SecurityGroup::Id>
 Resources:
   TestCluster:
-    Type: 'AWS::MSK::Cluster'
+    Type: AWS::MSK::Cluster
     Properties:
       ClusterName: ClusterWithAllProperties
       KafkaVersion: 2.2.1
@@ -15,9 +15,9 @@ Resources:
       EnhancedMonitoring: PER_BROKER
       EncryptionInfo:
         EncryptionAtRest:
-          DataVolumeKMSKeyId: ""
+          DataVolumeKMSKeyId: ''
         EncryptionInTransit:
-          ClientBroker: PLAINTEXT
+          ClientBroker: TLS
           InCluster: false
       Tags:
         Environment: Test
@@ -25,8 +25,8 @@ Resources:
       BrokerNodeGroupInfo:
         BrokerAZDistribution: DEFAULT
         InstanceType: kafka.m5.large
-        SecurityGroups: !Ref SecurityGroups
+        SecurityGroups: !Ref 'SecurityGroups'
         StorageInfo:
           EBSStorageInfo:
             VolumeSize: 100
-        ClientSubnets: !Ref SubnetIds
+        ClientSubnets: !Ref 'SubnetIds'


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-MSK-003 

 **Violation Description:** 

 Enable TLS by setting EncryptionInfo.EncryptionInTransit.ClientBroker value to 'TLS'. to provide trasport layes security to MSK instance 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-msk-cluster.html#cfn-msk-cluster-encryptioninfo' target='_blank'>here</a>