### PR TITLE
Fixed PR-AWS-CFR-RSH-002: AWS Redshift clusters should not be publicly accessible

### DIFF
--- a/redshift/redshift.yaml
+++ b/redshift/redshift.yaml
@@ -1,17 +1,17 @@
-AWSTemplateFormatVersion: 2010-09-09
+AWSTemplateFormatVersion: '2010-09-09'
 Resources:
   RedshiftCluster:
-    Type: 'AWS::Redshift::Cluster'
+    Type: AWS::Redshift::Cluster
     Properties:
       Encrypted: false
-      PubliclyAccessible: true
+      PubliclyAccessible: false
       DBName: mydb
       MasterUsername: master
       MasterUserPassword: Root12345
       NodeType: ds2.xlarge
       ClusterType: single-node
   RedshiftClusterParameterGroup:
-    Type: 'AWS::Redshift::ClusterParameterGroup'
+    Type: AWS::Redshift::ClusterParameterGroup
     Properties:
       Description: Cluster parameter group
       ParameterGroupFamily: redshift-1.0


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-RSH-002 

 **Violation Description:** 

 This policy identifies AWS Redshift clusters which are accessible publicly. 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-redshift-cluster.html' target='_blank'>here</a>