### PR TITLE
Fixed PR-AWS-CFR-RSH-003: AWS Redshift does not have require_ssl configured

### DIFF
--- a/redshift/redshift.yaml
+++ b/redshift/redshift.yaml
@@ -1,7 +1,7 @@
-AWSTemplateFormatVersion: 2010-09-09
+AWSTemplateFormatVersion: '2010-09-09'
 Resources:
   RedshiftCluster:
-    Type: 'AWS::Redshift::Cluster'
+    Type: AWS::Redshift::Cluster
     Properties:
       Encrypted: false
       PubliclyAccessible: true
@@ -11,10 +11,12 @@ Resources:
       NodeType: ds2.xlarge
       ClusterType: single-node
   RedshiftClusterParameterGroup:
-    Type: 'AWS::Redshift::ClusterParameterGroup'
+    Type: AWS::Redshift::ClusterParameterGroup
     Properties:
       Description: Cluster parameter group
       ParameterGroupFamily: redshift-1.0
       Parameters:
         - ParameterName: enable_user_activity_logging
           ParameterValue: true
+        - ParameterName: require_ssl
+          ParameterValue: 'true'


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-RSH-003 

 **Violation Description:** 

 This policy identifies Redshift databases in which data connection to and from is occurring on an insecure channel. SSL connections ensures the security of the data in transit. 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-redshift-cluster.html' target='_blank'>here</a>