### PR TITLE
Fixed PR-AWS-CFR-RSH-004: AWS Redshift instances are not encrypted

### DIFF
--- a/redshift/redshift.yaml
+++ b/redshift/redshift.yaml
@@ -1,9 +1,9 @@
-AWSTemplateFormatVersion: 2010-09-09
+AWSTemplateFormatVersion: '2010-09-09'
 Resources:
   RedshiftCluster:
-    Type: 'AWS::Redshift::Cluster'
+    Type: AWS::Redshift::Cluster
     Properties:
-      Encrypted: false
+      Encrypted: true
       PubliclyAccessible: true
       DBName: mydb
       MasterUsername: master
@@ -11,7 +11,7 @@ Resources:
       NodeType: ds2.xlarge
       ClusterType: single-node
   RedshiftClusterParameterGroup:
-    Type: 'AWS::Redshift::ClusterParameterGroup'
+    Type: AWS::Redshift::ClusterParameterGroup
     Properties:
       Description: Cluster parameter group
       ParameterGroupFamily: redshift-1.0


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-RSH-004 

 **Violation Description:** 

 This policy identifies AWS Redshift instances which are not encrypted. These instances should be encrypted for clusters to help protect data at rest which otherwise can result in a data breach. 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-redshift-cluster.html' target='_blank'>here</a>