### PR TITLE
Fixed PR-AWS-CFR-RSH-005: Ensure Redshift cluster allow version upgrade by default

### DIFF
--- a/redshift/redshift.yaml
+++ b/redshift/redshift.yaml
@@ -1,7 +1,7 @@
-AWSTemplateFormatVersion: 2010-09-09
+AWSTemplateFormatVersion: '2010-09-09'
 Resources:
   RedshiftCluster:
-    Type: 'AWS::Redshift::Cluster'
+    Type: AWS::Redshift::Cluster
     Properties:
       Encrypted: false
       PubliclyAccessible: true
@@ -10,8 +10,9 @@ Resources:
       MasterUserPassword: Root12345
       NodeType: ds2.xlarge
       ClusterType: single-node
+      AllowVersionUpgrade: true
   RedshiftClusterParameterGroup:
-    Type: 'AWS::Redshift::ClusterParameterGroup'
+    Type: AWS::Redshift::ClusterParameterGroup
     Properties:
       Description: Cluster parameter group
       ParameterGroupFamily: redshift-1.0


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-RSH-005 

 **Violation Description:** 

 This policy identifies AWS Redshift instances which has not enabled AllowVersionUpgrade. major version upgrades can be applied during the maintenance window to the Amazon Redshift engine that is running on the cluster. When a new major version of the Amazon Redshift engine is released, you can request that the service automatically apply upgrades during the maintenance window to the Amazon Redshift engine that is running on your cluster. 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-redshift-cluster.html#cfn-redshift-cluster-allowversionupgrade' target='_blank'>here</a>