### PR TITLE
Fixed PR-AWS-CFR-ACM-002: AWS Certificate Manager (ACM) has certificates with Certificate Transparency Logging disabled

### DIFF
--- a/acm/acm.yaml
+++ b/acm/acm.yaml
@@ -3,7 +3,7 @@ Parameters:
   domain:
     Type: String
     Description: DNS domain to create a SES email for
-    Default: "*"
+    Default: '*'
 Resources:
   SslCertificate:
     Type: AWS::CertificateManager::Certificate
@@ -12,4 +12,4 @@ Resources:
       SubjectAlternativeNames:
         - !Sub 'www.${domain}'
       ValidationMethod: EMAIL
-      CertificateTransparencyLoggingPreference: DISABLED
+      CertificateTransparencyLoggingPreference: ENABLED


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-ACM-002 

 **Violation Description:** 

 This policy identifies AWS Certificate Manager certificates in which Certificate Transparency Logging is disabled. AWS Certificate Manager (ACM) is the preferred tool to provision, manage, and deploy your server certificates. Certificate Transparency Logging is used to guard against SSL/TLS certificates that are issued by mistake or by a compromised CA, some browsers require that public certificates issued for your domain can also be recorded. This policy generates alerts for certificates which have transparency logging disabled. As a best practice, it is recommended to enable Transparency logging for all certificates. 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-certificatemanager-certificate.html' target='_blank'>here</a>