### PR TITLE
Fixed PR-AWS-CFR-ECR-001: Ensure ECR image tags are immutable

### DIFF
--- a/ecr/ecr.yaml
+++ b/ecr/ecr.yaml
@@ -1,12 +1,11 @@
-AWSTemplateFormatVersion: 2010-09-09
+AWSTemplateFormatVersion: '2010-09-09'
 Resources:
   MyRepository:
     Type: AWS::ECR::Repository
     Properties:
-      ImageTagMutability: MUTABLE
+      ImageTagMutability: IMMUTABLE
       ImageScanningConfiguration:
         ScanOnPush: true
-
       RepositoryPolicyText:
         Version: '2008-10-17'
         Statement:
@@ -14,7 +13,7 @@ Resources:
             Effect: Allow
             Principal:
               AWS:
-                - "*"
+                - '*'
                 - arn:aws:iam::123456789012:user/Alice
             Action:
               - ecr:GetDownloadUrlForLayer


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-ECR-001 

 **Violation Description:** 

 Amazon ECR supports immutable tags, preventing image tags from being overwritten. In the past, ECR tags could have been overwritten, this could be overcome by requiring users to uniquely identify an image using a naming convention.Tag Immutability enables users can rely on the descriptive tags of an image as a mechanism to track and uniquely identify images. By setting an image tag as immutable, developers can use the tag to correlate the deployed image version with the build that produced the image. 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecr-repository.html#cfn-ecr-repository-imagetagmutability' target='_blank'>here</a>