### PR TITLE
Fixed PR-AWS-CFR-EC2-004: Ensure that EC2 instace is EBS Optimized

### DIFF
--- a/ec2/ec2.yaml
+++ b/ec2/ec2.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: 2010-09-09
+AWSTemplateFormatVersion: '2010-09-09'
 Parameters:
   InstanceType:
     Description: WebServer EC2 instance type
@@ -49,23 +49,24 @@ Parameters:
       - d2.8xlarge
     ConstraintDescription: must be a valid EC2 instance type.
   LatestAmiId:
-    Type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
     Default: /aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2
 Resources:
   EC2Instance:
-    Type: 'AWS::EC2::Instance'
+    Type: AWS::EC2::Instance
     Properties:
-      InstanceType: !Ref InstanceType
-      ImageId: !Ref LatestAmiId
+      InstanceType: !Ref 'InstanceType'
+      ImageId: !Ref 'LatestAmiId'
       NetworkInterfaces:
         - AssociatePublicIpAddress: true
           DeviceIndex: 0
+      EbsOptimized: true
   NewVolume:
-    Type: 'AWS::EC2::Volume'
+    Type: AWS::EC2::Volume
     Properties:
       Size: 100
       Encrypted: false
-      AvailabilityZone: !Select 
+      AvailabilityZone: !Select
         - '0'
-        - !GetAZs 
-          Ref: 'AWS::Region'
+        - !GetAZs
+          Ref: AWS::Region


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-EC2-004 

 **Violation Description:** 

 Enable EbsOptimized provides dedicated throughput to Amazon EBS and an optimized configuration stack to provide optimal Amazon EBS I/O performance 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-instance.html#cfn-ec2-instance-ebsoptimized' target='_blank'>here</a>