### PR TITLE
Fixed PR-AWS-CFR-ECS-001: AWS ECS task definition elevated privileges enabled

### DIFF
--- a/ecs/ecs.yaml
+++ b/ecs/ecs.yaml
@@ -33,11 +33,11 @@ Resources:
       RequiresCompatibilities:
         - FARGATE
       ContainerDefinitions:
-        - Name: !Ref 'ServiceName'
-          User: 'root'
-          Cpu: !Ref 'ContainerCpu'
-          Memory: !Ref 'ContainerMemory'
-          Image: !Ref 'ImageUrl'
-          Privileged: true
+        - Name: nginx
+          User: root
+          Cpu: 0
+          Memory: 0
+          Image: nginx
+          Privileged: false
           PortMappings:
-            - ContainerPort: !Ref 'ContainerPort'
+            - ContainerPort: 80


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-ECS-001 

 **Violation Description:** 

 Ensure your ECS containers are not given elevated privileges on the host container instance. When the Privileged parameter is true, the container is given elevated privileges on the host container instance (similar to the root user). This policy checks the security configuration of your task definition and alerts if elevated privileges are enabled. Note: This parameter is not supported for Windows containers or tasks using the Fargate launch type. 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html' target='_blank'>here</a>