### PR TITLE
Fixed PR-AWS-CFR-ECS-004: AWS ECS Task Definition readonlyRootFilesystem Not Enabled

### DIFF
--- a/ecs/ecs.yaml
+++ b/ecs/ecs.yaml
@@ -33,11 +33,12 @@ Resources:
       RequiresCompatibilities:
         - FARGATE
       ContainerDefinitions:
-        - Name: !Ref 'ServiceName'
-          User: 'root'
-          Cpu: !Ref 'ContainerCpu'
-          Memory: !Ref 'ContainerMemory'
-          Image: !Ref 'ImageUrl'
+        - Name: nginx
+          User: root
+          Cpu: 0
+          Memory: 0
+          Image: nginx
           Privileged: true
           PortMappings:
-            - ContainerPort: !Ref 'ContainerPort'
+            - ContainerPort: 80
+          ReadonlyRootFilesystem: true


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-ECS-004 

 **Violation Description:** 

 It is recommended that readonlyRootFilesystem is enabled for AWS ECS task definition. Please make sure your 'ContainerDefinitions' template has 'ReadonlyRootFilesystem' and is set to 'true'. 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html' target='_blank'>here</a>