### PR TITLE
Fixed PR-AWS-CFR-ECS-005: AWS ECS task definition resource limits not set.

### DIFF
--- a/ecs/ecs.yaml
+++ b/ecs/ecs.yaml
@@ -16,11 +16,11 @@ Parameters:
       to
   ContainerCpu:
     Type: Number
-    Default: 0
+    Default: 256
     Description: How much CPU to give the container. 1024 is 1 CPU
   ContainerMemory:
     Type: Number
-    Default: 0
+    Default: 512
     Description: How much memory in megabytes to give the container
 Resources:
   TaskDefinition:
@@ -33,11 +33,11 @@ Resources:
       RequiresCompatibilities:
         - FARGATE
       ContainerDefinitions:
-        - Name: !Ref 'ServiceName'
-          User: 'root'
-          Cpu: !Ref 'ContainerCpu'
-          Memory: !Ref 'ContainerMemory'
-          Image: !Ref 'ImageUrl'
+        - Name: nginx
+          User: root
+          Cpu: 256
+          Memory: 512
+          Image: nginx
           Privileged: true
           PortMappings:
-            - ContainerPort: !Ref 'ContainerPort'
+            - ContainerPort: 80


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-ECS-005 

 **Violation Description:** 

 It is recommended that resource limits are set for AWS ECS task definition. Please make sure attributes 'Cpu' or 'Memory' exists and its value is not set to 0 under 'TaskDefinition' or 'ContainerDefinitions'. 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html' target='_blank'>here</a>