### PR TITLE
Fixed PR-AWS-CFR-LMD-003: AWS Lambda functions with tracing not enabled

### DIFF
--- a/leaked_secret/secret.yaml
+++ b/leaked_secret/secret.yaml
@@ -1,38 +1,33 @@
-AWSTemplateFormatVersion: 2010-09-09
+AWSTemplateFormatVersion: '2010-09-09'
 Resources:
   MyProxyFunction:
-    Type: 'AWS::Lambda::Function'
+    Type: AWS::Lambda::Function
     Properties:
-      Environment: 
+      Environment:
         Variables:
-          AWS_SECRET_ACCESS_KEY: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-          AWS_ACCESS_KEY_ID: "ASIAIOSFODNN7EXAMPLE"
-          AWS_ACCOUNT_ID: "123456789012"
+          AWS_SECRET_ACCESS_KEY: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+          AWS_ACCESS_KEY_ID: ASIAIOSFODNN7EXAMPLE
+          AWS_ACCOUNT_ID: '123456789012'
       Runtime: nodejs12.x
-      Role: !GetAtt 
-        - FunctionExecutionRole
-        - Arn
+      Role: !GetAtt 'FunctionExecutionRole.Arn'
       Handler: index.handler
       Code:
-        ZipFile: |
-          exports.handler = async (event) => {
-              const response = {
-                  statusCode: 200,
-                  body: JSON.stringify('Hello from Lambda!'),
-              };
-              return response;
-          };
+        ZipFile: "exports.handler = async (event) => {\n    const response = {\n \
+          \       statusCode: 200,\n        body: JSON.stringify('Hello from Lambda!'),\n\
+          \    };\n    return response;\n};\n"
+      TracingConfig:
+        Mode: Active
   FunctionExecutionRole:
-    Type: 'AWS::IAM::Role'
+    Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
           - Effect: Allow
             Principal:
               Service:
                 - lambda.amazonaws.com
             Action:
-              - 'sts:AssumeRole'
+              - sts:AssumeRole
       ManagedPolicyArns:
-        - 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-LMD-003 

 **Violation Description:** 

 TracingConfig is a property of the AWS::Lambda::Function resource that configures tracing settings for your AWS Lambda (Lambda) function. When enabled, AWS Lambda tracing acitivates AWS X-Ray service that collects information on requests that a specific function performed. It reduces the time and effort for debugging and diagnosing the errors._x005F_x000D_ _x005F_x000D_ The value can be either PassThrough or Active. If PassThrough, Lambda will only trace the request from an upstream service if it contains a tracing header with 'sampled=1'. If Active, Lambda will respect any tracing header it receives from an upstream service. If no tracing header is received, Lambda will call X-Ray for a tracing decision. 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html' target='_blank'>here</a>