### PR TITLE
Fixed PR-AWS-CFR-LMD-003: AWS Lambda functions with tracing not enabled

### DIFF
--- a/lambda/lambda-sample.yaml
+++ b/lambda/lambda-sample.yaml
@@ -1,72 +1,64 @@
-AWSTemplateFormatVersion: 2010-09-09
+AWSTemplateFormatVersion: '2010-09-09'
 Description: Template for Lambda Sample.
 Parameters:
   EnvName:
     Type: String
-    Description: 'Name of an environment. ''dev'', ''staging'', ''prod'' and any name.'
-    AllowedPattern: '^.*[^0-9]$'
+    Description: Name of an environment. 'dev', 'staging', 'prod' and any name.
+    AllowedPattern: ^.*[^0-9]$
     ConstraintDescription: Must end with non-numeric character.
   LambdaHandlerPath:
     Type: String
     Description: Path of a Lambda Handler.
-    AllowedPattern: '^.*[^0-9]$'
+    AllowedPattern: ^.*[^0-9]$
     ConstraintDescription: Must end with non-numeric character.
 Outputs:
   LambdaRoleARN:
     Description: Role for Lambda execution.
-    Value: !GetAtt 
-      - LambdaRole
-      - Arn
+    Value: !GetAtt 'LambdaRole.Arn'
     Export:
-      Name: !Sub LambdaRole
+      Name: !Sub 'LambdaRole'
   LambdaFunctionName:
-    Value: !Ref LambdaFunction
+    Value: !Ref 'LambdaFunction'
   LambdaFunctionARN:
     Description: Lambda function ARN.
-    Value: !GetAtt 
-      - LambdaFunction
-      - Arn
+    Value: !GetAtt 'LambdaFunction.Arn'
     Export:
       Name: !Sub 'LambdaARN-${EnvName}'
 Resources:
   LambdaRole:
-    Type: 'AWS::IAM::Role'
+    Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub lambda-role
+      RoleName: !Sub 'lambda-role'
       AssumeRolePolicyDocument:
         Statement:
           - Action:
-              - 'sts:AssumeRole'
+              - sts:AssumeRole
             Effect: Allow
             Principal:
               Service:
                 - lambda.amazonaws.com
-        Version: 2012-10-17
+        Version: '2012-10-17'
       ManagedPolicyArns:
-        - 'arn:aws:iam::aws:policy/AWSLambdaExecute'
-        - 'arn:aws:iam::aws:policy/AmazonS3FullAccess'
-        - 'arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess'
-        - 'arn:aws:iam::aws:policy/AmazonKinesisFullAccess'
+        - arn:aws:iam::aws:policy/AWSLambdaExecute
+        - arn:aws:iam::aws:policy/AmazonS3FullAccess
+        - arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess
+        - arn:aws:iam::aws:policy/AmazonKinesisFullAccess
       Path: /
   LambdaFunction:
-    Type: 'AWS::Lambda::Function'
+    Type: AWS::Lambda::Function
     Properties:
       PackageType: Image
       FunctionName: !Sub 'lambda-function-${EnvName}'
       Description: LambdaFunctioni of nodejs10.x.
       Runtime: nodejs10.x
       Code:
-        ZipFile: |-
-          exports.handler = function(event, context){
-           var sample = sample;
-      Handler: '${LambdaHandlerPath}'
+        ZipFile: "exports.handler = function(event, context){\n var sample = sample;"
+      Handler: ${LambdaHandlerPath}
       MemorySize: 128
       Timeout: 10
-      Role: !GetAtt 
-        - LambdaRole
-        - Arn
+      Role: !GetAtt 'LambdaRole.Arn'
       TracingConfig:
-        Mode: PassThrough
+        Mode: Active
       Environment:
         Variables:
           ENV: !Sub '${EnvName}'
@@ -75,23 +67,15 @@ Resources:
     Type: AWS::Lambda::EventSourceMapping
     Properties:
       SourceAccessConfigurations:
-        - Type: "BASIC_AUTH"
-          URI: "http://localhost:8000"
-      EventSourceArn:
-        Fn::Join:
-          - ""
-          -
-            - "arn:aws:kinesis:"
-            -
-              Ref: "AWS::Region"
-            - ":"
-            -
-              Ref: "AWS::AccountId"
-            - ":stream/"
-            -
-              Ref: "KinesisStream"
-      FunctionName:
-        Fn::GetAtt:
-          - "LambdaFunction"
-          - "Arn"
-      StartingPosition: "TRIM_HORIZON"
+        - Type: BASIC_AUTH
+          URI: http://localhost:8000
+      EventSourceArn: !Join
+        - ''
+        - - 'arn:aws:kinesis:'
+          - !Ref 'AWS::Region'
+          - ':'
+          - !Ref 'AWS::AccountId'
+          - :stream/
+          - !Ref 'KinesisStream'
+      FunctionName: !GetAtt 'LambdaFunction.Arn'
+      StartingPosition: TRIM_HORIZON


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-LMD-003 

 **Violation Description:** 

 TracingConfig is a property of the AWS::Lambda::Function resource that configures tracing settings for your AWS Lambda (Lambda) function. When enabled, AWS Lambda tracing acitivates AWS X-Ray service that collects information on requests that a specific function performed. It reduces the time and effort for debugging and diagnosing the errors._x005F_x000D_ _x005F_x000D_ The value can be either PassThrough or Active. If PassThrough, Lambda will only trace the request from an upstream service if it contains a tracing header with 'sampled=1'. If Active, Lambda will respect any tracing header it receives from an upstream service. If no tracing header is received, Lambda will call X-Ray for a tracing decision. 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html' target='_blank'>here</a>