### PR TITLE
Fixed PR-AWS-CFR-CF-002: AWS CloudFront distribution is using insecure SSL protocols for HTTPS communication

### DIFF
--- a/cloudfront/cloudfront.yaml
+++ b/cloudfront/cloudfront.yaml
@@ -1,7 +1,7 @@
-AWSTemplateFormatVersion: 2010-09-09
+AWSTemplateFormatVersion: '2010-09-09'
 Resources:
   myDistribution:
-    Type: 'AWS::CloudFront::Distribution'
+    Type: AWS::CloudFront::Distribution
     Properties:
       DistributionConfig:
         Origins:
@@ -15,7 +15,7 @@ Resources:
                 - TLSv1
                 - TLSv1.1
                 - TLSv1.2
-                - SSLv3
+                - TLSv1.2
         Enabled: 'true'
         Comment: Some comment
         DefaultCacheBehavior:
@@ -34,5 +34,5 @@ Resources:
             Cookies:
               Forward: none
         ViewerCertificate:
-          MinimumProtocolVersion: SSLv3
+          MinimumProtocolVersion: TLSv1.2_2021
           CloudFrontDefaultCertificate: 'true'


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-CF-002 

 **Violation Description:** 

 CloudFront, a content delivery network (CDN) offered by AWS, is not using a secure cipher for distribution. It is a best security practice to enforce the use of secure ciphers TLSv1.0, TLSv1.1, and/or TLSv1.2 in a CloudFront Distribution's certificate configuration. This policy scans for any deviations from this practice and returns the results. 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudfront-distribution.html' target='_blank'>here</a>