### PR TITLE
Fixed PR-AWS-CFR-CF-004: AWS CloudFront origin protocol policy does not enforce HTTPS-only

### DIFF
--- a/cloudfront/cloudfront.yaml
+++ b/cloudfront/cloudfront.yaml
@@ -1,7 +1,7 @@
-AWSTemplateFormatVersion: 2010-09-09
+AWSTemplateFormatVersion: '2010-09-09'
 Resources:
   myDistribution:
-    Type: 'AWS::CloudFront::Distribution'
+    Type: AWS::CloudFront::Distribution
     Properties:
       DistributionConfig:
         Origins:
@@ -10,7 +10,7 @@ Resources:
             CustomOriginConfig:
               HTTPPort: '80'
               HTTPSPort: '443'
-              OriginProtocolPolicy: http-only
+              OriginProtocolPolicy: https-only
               OriginSSLProtocols:
                 - TLSv1
                 - TLSv1.1


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-CF-004 

 **Violation Description:** 

 It is a best security practice to enforce HTTPS-only traffic between a CloudFront distribution and the origin. This policy scans for any deviations from this practice and returns the results. 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudfront-distribution.html' target='_blank'>here</a>