### PR TITLE
Fixed PR-AWS-CFR-CF-005: AWS CloudFront viewer protocol policy is not configured with HTTPS

### DIFF
--- a/cloudfront/cloudfront.yaml
+++ b/cloudfront/cloudfront.yaml
@@ -1,7 +1,7 @@
-AWSTemplateFormatVersion: 2010-09-09
+AWSTemplateFormatVersion: '2010-09-09'
 Resources:
   myDistribution:
-    Type: 'AWS::CloudFront::Distribution'
+    Type: AWS::CloudFront::Distribution
     Properties:
       DistributionConfig:
         Origins:
@@ -28,7 +28,7 @@ Resources:
             - POST
             - PUT
           TargetOriginId: myS3Origin
-          ViewerProtocolPolicy: allow-all
+          ViewerProtocolPolicy: https-only
           ForwardedValues:
             QueryString: 'false'
             Cookies:


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-CF-005 

 **Violation Description:** 

 For web distributions, you can configure CloudFront to require that viewers use HTTPS to request your objects, so connections are encrypted when CloudFront communicates with viewers. 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudfront-distribution.html' target='_blank'>here</a>