### PR TITLE
Fixed PR-AWS-CFR-RDS-008: AWS RDS instance with copy tags to snapshots disabled

### DIFF
--- a/secret_manager/secret_manager.yaml
+++ b/secret_manager/secret_manager.yaml
@@ -1,4 +1,3 @@
----
 AWSTemplateFormatVersion: '2010-09-09'
 Resources:
   TestVPC:
@@ -11,40 +10,32 @@ Resources:
     Type: AWS::EC2::Subnet
     Properties:
       CidrBlock: 10.0.96.0/19
-      AvailabilityZone:
-        Fn::Select:
+      AvailabilityZone: !Select
         - '0'
-        - Fn::GetAZs:
-            Ref: AWS::Region
-      VpcId:
-        Ref: TestVPC
+        - !GetAZs
+          Ref: AWS::Region
+      VpcId: !Ref 'TestVPC'
   TestSubnet02:
     Type: AWS::EC2::Subnet
     Properties:
       CidrBlock: 10.0.128.0/19
-      AvailabilityZone:
-        Fn::Select:
+      AvailabilityZone: !Select
         - '1'
-        - Fn::GetAZs:
-            Ref: AWS::Region
-      VpcId:
-        Ref: TestVPC
+        - !GetAZs
+          Ref: AWS::Region
+      VpcId: !Ref 'TestVPC'
   SecretsManagerVPCEndpoint:
     Type: AWS::EC2::VPCEndpoint
     Properties:
       SubnetIds:
-      - Ref: TestSubnet01
-      - Ref: TestSubnet02
+        - !Ref 'TestSubnet01'
+        - !Ref 'TestSubnet02'
       SecurityGroupIds:
-      - Fn::GetAtt:
-        - TestVPC
-        - DefaultSecurityGroup
+        - !GetAtt 'TestVPC.DefaultSecurityGroup'
       VpcEndpointType: Interface
-      ServiceName:
-        Fn::Sub: com.amazonaws.${AWS::Region}.secretsmanager
+      ServiceName: !Sub 'com.amazonaws.${AWS::Region}.secretsmanager'
       PrivateDnsEnabled: true
-      VpcId:
-        Ref: TestVPC
+      VpcId: !Ref 'TestVPC'
   MyRDSInstanceRotationSecret:
     Type: AWS::SecretsManager::Secret
     Properties:
@@ -52,54 +43,44 @@ Resources:
         SecretStringTemplate: '{"username": "admin"}'
         GenerateStringKey: password
         PasswordLength: 16
-        ExcludeCharacters: "\"@/\\"
+        ExcludeCharacters: '"@/\'
       Tags:
-      - Key: AppName
-        Value: MyApp
+        - Key: AppName
+          Value: MyApp
   MyDBInstance:
     Type: AWS::RDS::DBInstance
     Properties:
       AllocatedStorage: 20
       DBInstanceClass: db.t3.micro
       Engine: mysql
-      DBSubnetGroupName:
-        Ref: MyDBSubnetGroup
-      MasterUsername:
-        Fn::Sub: "{{resolve:secretsmanager:${MyRDSInstanceRotationSecret}::username}}"
-      MasterUserPassword:
-        Fn::Sub: "{{resolve:secret:${MyRDSInstanceRotationSecret}::password}}"
+      DBSubnetGroupName: !Ref 'MyDBSubnetGroup'
+      MasterUsername: !Sub '{{resolve:secretsmanager:${MyRDSInstanceRotationSecret}::username}}'
+      MasterUserPassword: !Sub '{{resolve:secret:${MyRDSInstanceRotationSecret}::password}}'
       BackupRetentionPeriod: 0
       VPCSecurityGroups:
-      - Fn::GetAtt:
-        - TestVPC
-        - DefaultSecurityGroup
+        - !GetAtt 'TestVPC.DefaultSecurityGroup'
+      CopyTagsToSnapshot: true
   MyDBSubnetGroup:
     Type: AWS::RDS::DBSubnetGroup
     Properties:
       DBSubnetGroupDescription: Test Group
       SubnetIds:
-      - Ref: TestSubnet01
-      - Ref: TestSubnet02
+        - !Ref 'TestSubnet01'
+        - !Ref 'TestSubnet02'
   SecretRDSInstanceAttachment:
     Type: AWS::SecretsManager::SecretTargetAttachment
     Properties:
-      SecretId:
-        Ref: MyRDSInstanceRotationSecret
-      TargetId:
-        Ref: MyDBInstance
+      SecretId: !Ref 'MyRDSInstanceRotationSecret'
+      TargetId: !Ref 'MyDBInstance'
       TargetType: AWS::RDS::DBInstance
   MySecretRotationSchedule:
     Type: AWS::SecretsManager::RotationSchedule
     DependsOn: SecretRDSInstanceAttachment
     Properties:
-      SecretId:
-        Ref: MyRDSInstanceRotationSecret
+      SecretId: !Ref 'MyRDSInstanceRotationSecret'
       HostedRotationLambda:
         RotationType: MySQLSingleUser
         RotationLambdaName: SecretsManagerRotation
-        VpcSecurityGroupIds:
-          Fn::GetAtt:
-          - TestVPC
-          - DefaultSecurityGroup
+        VpcSecurityGroupIds: !GetAtt 'TestVPC.DefaultSecurityGroup'
       RotationRules:
         AutomaticallyAfterDays: 30


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-RDS-008 

 **Violation Description:** 

 This policy identifies RDS instances which have copy tags to snapshots disabled. Copy tags to snapshots copies all the user-defined tags from the DB instance to snapshots. Copying tags allow you to add metadata and apply access policies to your Amazon RDS resources. 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbcluster.html' target='_blank'>here</a>