### PR TITLE
Fixed PR-AWS-CFR-ELB-001: AWS Elastic Load Balancer (Classic) SSL negotiation policy configured with insecure ciphers

### DIFF
--- a/elb/elb.yaml
+++ b/elb/elb.yaml
@@ -1,27 +1,29 @@
-AWSTemplateFormatVersion: 2010-09-09
+AWSTemplateFormatVersion: '2010-09-09'
 Description: Elastic Load Balancer
 Parameters:
   VPC:
-    Type: 'AWS::EC2::VPC::Id'
-    Description: Choose which VPC the Application Load Balancer should be deployed to
+    Type: AWS::EC2::VPC::Id
+    Description: Choose which VPC the Application Load Balancer should be deployed
+      to
   Subnets:
-    Description: Choose which subnets the Application Load Balancer should be deployed to
-    Type: 'List<AWS::EC2::Subnet::Id>'
+    Description: Choose which subnets the Application Load Balancer should be deployed
+      to
+    Type: List<AWS::EC2::Subnet::Id>
 Resources:
   S3BUCKET:
-    Type: 'AWS::S3::Bucket'
+    Type: AWS::S3::Bucket
     DeletionPolicy: Retain
     Properties:
       VersioningConfiguration:
         Status: Enabled
   MyLoadBalancer:
-    Type: 'AWS::ElasticLoadBalancing::LoadBalancer'
+    Type: AWS::ElasticLoadBalancing::LoadBalancer
     Properties:
       AccessLoggingPolicy:
         Enabled: false
-        S3BucketName: !Ref S3BUCKET
+        S3BucketName: !Ref 'S3BUCKET'
       CrossZone: false
-      Subnets: !Ref Subnets
+      Subnets: !Ref 'Subnets'
       ConnectionDrainingPolicy:
         Enabled: false
       Listeners:
@@ -31,151 +33,151 @@ Resources:
           Protocol: HTTPS
           PolicyNames:
             - My-SSLNegotiation-Policy
-          SSLCertificateId: 'arn:aws:iam::123456789012:server-certificate/my-server-certificate'
+          SSLCertificateId: arn:aws:iam::123456789012:server-certificate/my-server-certificate
       Policies:
         - PolicyName: My-SSLNegotiation-Policy
           PolicyType: SSLNegotiationPolicyType
           Attributes:
             - Name: DHE-RSA-AES128-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: DHE-DSS-AES128-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: CAMELLIA128-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: EDH-RSA-DES-CBC3-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: DES-CBC3-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: ECDHE-RSA-RC4-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: RC4-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: ECDHE-ECDSA-RC4-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: DHE-DSS-AES256-GCM-SHA384
-              Value: 'true'
+              Value: 'false'
             - Name: DHE-RSA-AES256-GCM-SHA384
-              Value: 'true'
+              Value: 'false'
             - Name: DHE-RSA-AES256-SHA256
-              Value: 'true'
+              Value: 'false'
             - Name: DHE-DSS-AES256-SHA256
-              Value: 'true'
+              Value: 'false'
             - Name: DHE-RSA-AES256-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: DHE-DSS-AES256-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: DHE-RSA-CAMELLIA256-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: DHE-DSS-CAMELLIA256-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: CAMELLIA256-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: EDH-DSS-DES-CBC3-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: DHE-DSS-AES128-GCM-SHA256
-              Value: 'true'
+              Value: 'false'
             - Name: DHE-RSA-AES128-GCM-SHA256
-              Value: 'true'
+              Value: 'false'
             - Name: DHE-RSA-AES128-SHA256
-              Value: 'true'
+              Value: 'false'
             - Name: DHE-DSS-AES128-SHA256
-              Value: 'true'
+              Value: 'false'
             - Name: DHE-RSA-CAMELLIA128-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: DHE-DSS-CAMELLIA128-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: ADH-AES128-GCM-SHA256
-              Value: 'true'
+              Value: 'false'
             - Name: ADH-AES128-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: ADH-AES128-SHA256
-              Value: 'true'
+              Value: 'false'
             - Name: ADH-AES256-GCM-SHA384
-              Value: 'true'
+              Value: 'false'
             - Name: ADH-AES256-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: ADH-AES256-SHA256
-              Value: 'true'
+              Value: 'false'
             - Name: ADH-CAMELLIA128-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: ADH-CAMELLIA256-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: ADH-DES-CBC3-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: ADH-DES-CBC-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: ADH-RC4-MD5
-              Value: 'true'
+              Value: 'false'
             - Name: ADH-SEED-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: DES-CBC-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: DHE-DSS-SEED-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: DHE-RSA-SEED-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: EDH-DSS-DES-CBC-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: EDH-RSA-DES-CBC-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: IDEA-CBC-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: RC4-MD5
-              Value: 'true'
+              Value: 'false'
             - Name: SEED-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: DES-CBC3-MD5
-              Value: 'true'
+              Value: 'false'
             - Name: DES-CBC-MD5
-              Value: 'true'
+              Value: 'false'
             - Name: RC2-CBC-MD5
-              Value: 'true'
+              Value: 'false'
             - Name: PSK-AES256-CBC-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: PSK-3DES-EDE-CBC-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: KRB5-DES-CBC3-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: KRB5-DES-CBC3-MD5
-              Value: 'true'
+              Value: 'false'
             - Name: PSK-AES128-CBC-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: PSK-RC4-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: KRB5-RC4-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: KRB5-RC4-MD5
-              Value: 'true'
+              Value: 'false'
             - Name: KRB5-DES-CBC-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: KRB5-DES-CBC-MD5
-              Value: 'true'
+              Value: 'false'
             - Name: EXP-EDH-RSA-DES-CBC-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: EXP-EDH-DSS-DES-CBC-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: EXP-ADH-DES-CBC-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: EXP-DES-CBC-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: EXP-RC2-CBC-MD5
-              Value: 'true'
+              Value: 'false'
             - Name: EXP-KRB5-RC2-CBC-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: EXP-KRB5-DES-CBC-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: EXP-KRB5-RC2-CBC-MD5
-              Value: 'true'
+              Value: 'false'
             - Name: EXP-KRB5-DES-CBC-MD5
-              Value: 'true'
+              Value: 'false'
             - Name: EXP-ADH-RC4-MD5
-              Value: 'true'
+              Value: 'false'
             - Name: EXP-RC4-MD5
-              Value: 'true'
+              Value: 'false'
             - Name: EXP-KRB5-RC4-SHA
-              Value: 'true'
+              Value: 'false'
             - Name: EXP-KRB5-RC4-MD5
-              Value: 'true'
+              Value: 'false'
             - Name: Protocol-SSLv3
               Value: 'true'
             - Name: Protocol-TLSv1
@@ -183,40 +185,40 @@ Resources:
             - Name: Protocol-TLSv1.1
               Value: 'true'
   MyLoadBalancerV2:
-    Type: 'AWS::ElasticLoadBalancingV2::LoadBalancer'
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
       LoadBalancerAttributes:
         - Key: access_logs.s3.enabled
           Value: false
-      Subnets: !Ref Subnets
+      Subnets: !Ref 'Subnets'
   DummyTargetGroupPublic:
-    Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
       HealthCheckIntervalSeconds: 6
       HealthCheckPath: /
       HealthCheckProtocol: HTTP
       HealthCheckTimeoutSeconds: 5
       HealthyThresholdCount: 2
-      Name: !Join 
+      Name: !Join
         - '-'
         - - !Ref 'AWS::StackName'
           - drop-1
       Port: 80
       Protocol: HTTP
       UnhealthyThresholdCount: 2
-      VpcId: !Ref VPC
+      VpcId: !Ref 'VPC'
   PublicLoadBalancerListener:
-    Type: 'AWS::ElasticLoadBalancingV2::Listener'
+    Type: AWS::ElasticLoadBalancingV2::Listener
     DependsOn:
       - MyLoadBalancerV2
     Properties:
       DefaultActions:
-        - TargetGroupArn: !Ref DummyTargetGroupPublic
+        - TargetGroupArn: !Ref 'DummyTargetGroupPublic'
           Type: redirect
           RedirectConfig:
             Protocol: http
-        - TargetGroupArn: !Ref DummyTargetGroupPublic
+        - TargetGroupArn: !Ref 'DummyTargetGroupPublic'
           Type: authenticate-cognito
-      LoadBalancerArn: !Ref MyLoadBalancerV2
+      LoadBalancerArn: !Ref 'MyLoadBalancerV2'
       Port: 80
       Protocol: HTTP


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-ELB-001 

 **Violation Description:** 

 This policy identifies Elastic Load Balancers (Classic) which are configured with SSL negotiation policy containing insecure ciphers. An SSL cipher is an encryption algorithm that uses encryption keys to create a coded message. SSL protocols use several SSL ciphers to encrypt data over the Internet. As many of the other ciphers are not secure, it is recommended to use only the ciphers recommended in the following AWS link: https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-ssl-security-policy.html. 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-elb.html' target='_blank'>here</a>