### PR TITLE
Fixed PR-AWS-CFR-RDS-013: Ensure RDS clusters and instances have deletion protection enabled

### DIFF
--- a/rds/rds.yaml
+++ b/rds/rds.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: 2010-09-09
+AWSTemplateFormatVersion: '2010-09-09'
 Description: Aurora serverless cluster
 Parameters:
   DatabaseName:
@@ -15,7 +15,7 @@ Parameters:
     NoEcho: true
     Default: masterpassword
   VpcSecurityGroupId:
-    Type: 'AWS::EC2::SecurityGroup::Id'
+    Type: AWS::EC2::SecurityGroup::Id
   DBUser:
     NoEcho: 'true'
     Description: The database admin account username
@@ -24,7 +24,8 @@ Parameters:
     MinLength: '1'
     MaxLength: '16'
     AllowedPattern: '[a-zA-Z][a-zA-Z0-9]*'
-    ConstraintDescription: must begin with a letter and contain only alphanumeric characters.
+    ConstraintDescription: must begin with a letter and contain only alphanumeric
+      characters.
   DBPassword:
     NoEcho: 'true'
     Description: The database admin account password
@@ -36,37 +37,36 @@ Parameters:
     ConstraintDescription: must contain only alphanumeric characters.
 Resources:
   Cluster:
-    Type: 'AWS::RDS::DBCluster'
+    Type: AWS::RDS::DBCluster
     Properties:
       Engine: aurora
       EngineMode: serverless
-      EngineVersion: !Ref EngineVersion
-      DatabaseName: !Ref DatabaseName
-      MasterUsername: !Ref MasterUsername
+      EngineVersion: !Ref 'EngineVersion'
+      DatabaseName: !Ref 'DatabaseName'
+      MasterUsername: !Ref 'MasterUsername'
       MasterUserPassword: Root1234
       BackupRetentionPeriod: 0
-      DeletionProtection: false
+      DeletionProtection: true
       StorageEncrypted: false
       VpcSecurityGroupIds:
-        - !Ref VpcSecurityGroupId
+        - !Ref 'VpcSecurityGroupId'
   myDB:
-    Type: 'AWS::RDS::DBInstance'
+    Type: AWS::RDS::DBInstance
     Properties:
       AllocatedStorage: '100'
       DBInstanceClass: db.t2.small
       Engine: MySQL
       Iops: '1000'
-      MasterUsername: !Ref DBUser
-      MasterUserPassword: !Ref DBPassword
+      MasterUsername: !Ref 'DBUser'
+      MasterUserPassword: !Ref 'DBPassword'
       StorageEncrypted: false
       MultiAZ: false
       CopyTagsToSnapshot: false
       BackupRetentionPeriod: 0
       AutoMinorVersionUpgrade: false
       PubliclyAccessible: true
-
   GlobalCluster:
-    Type: 'AWS::RDS::GlobalCluster'
+    Type: AWS::RDS::GlobalCluster
     Properties:
-      GlobalClusterIdentifier: ""
-      SourceDBClusterIdentifier: !Ref Cluster
+      GlobalClusterIdentifier: ''
+      SourceDBClusterIdentifier: !Ref 'Cluster'


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-RDS-013 

 **Violation Description:** 

 This rule Checks if an Amazon Relational Database Service (Amazon RDS) cluster has deletion protection enabled 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbcluster.html' target='_blank'>here</a>