### PR TITLE
Fixed PR-AWS-CFR-ATH-001: Ensure to enable EnforceWorkGroupConfiguration for athena workgroup

### DIFF
--- a/Athena/athena.yaml
+++ b/Athena/athena.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: 2010-09-09
+AWSTemplateFormatVersion: '2010-09-09'
 Resources:
   MyAthenaWorkGroup:
     Type: AWS::Athena::WorkGroup
@@ -8,6 +8,6 @@ Resources:
       State: ENABLED
       WorkGroupConfiguration:
         BytesScannedCutoffPerQuery: 200000000
-        EnforceWorkGroupConfiguration: false
+        EnforceWorkGroupConfiguration: true
         PublishCloudWatchMetricsEnabled: false
         RequesterPaysEnabled: true


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-ATH-001 

 **Violation Description:** 

 Athena workgroups support the ability for clients to override configuration options, including encryption requirements. This setting should be disabled to enforce encryption mandates 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-docdb-dbcluster.html#cfn-docdb-dbcluster-storageencrypted' target='_blank'>here</a>