### PR TITLE
Fixed PR-AWS-CFR-DD-002: Ensure DynamoDB PITR is enabled

### DIFF
--- a/dynamodb/dynamodb.yaml
+++ b/dynamodb/dynamodb.yaml
@@ -1,79 +1,66 @@
-AWSTemplateFormatVersion: "2010-09-09"
-Resources: 
-  myDynamoDBTable: 
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  myDynamoDBTable:
     Type: AWS::DynamoDB::Table
-    Properties: 
-      AttributeDefinitions: 
-        - 
-          AttributeName: "Album"
-          AttributeType: "S"
-        - 
-          AttributeName: "Artist"
-          AttributeType: "S"
-        - 
-          AttributeName: "Sales"
-          AttributeType: "N"
-        - 
-          AttributeName: "NumberOfSongs"
-          AttributeType: "N"
-      KeySchema: 
-        - 
-          AttributeName: "Album"
-          KeyType: "HASH"
-        - 
-          AttributeName: "Artist"
-          KeyType: "RANGE"
-      ProvisionedThroughput: 
-        ReadCapacityUnits: "5"
-        WriteCapacityUnits: "5"
-      TableName: "myTableName"
-      GlobalSecondaryIndexes: 
-        - 
-          IndexName: "myGSI"
-          KeySchema: 
-            - 
-              AttributeName: "Sales"
-              KeyType: "HASH"
-            - 
-              AttributeName: "Artist"
-              KeyType: "RANGE"
-          Projection: 
-            NonKeyAttributes: 
-              - "Album"
-              - "NumberOfSongs"
-            ProjectionType: "INCLUDE"
-          ProvisionedThroughput: 
-            ReadCapacityUnits: "5"
-            WriteCapacityUnits: "5"
-        - 
-          IndexName: "myGSI2"
-          KeySchema: 
-            - 
-              AttributeName: "NumberOfSongs"
-              KeyType: "HASH"
-            - 
-              AttributeName: "Sales"
-              KeyType: "RANGE"
-          Projection: 
-            NonKeyAttributes: 
-              - "Album"
-              - "Artist"
-            ProjectionType: "INCLUDE"
-          ProvisionedThroughput: 
-            ReadCapacityUnits: "5"
-            WriteCapacityUnits: "5"
-      LocalSecondaryIndexes: 
-        - 
-          IndexName: "myLSI"
-          KeySchema: 
-            - 
-              AttributeName: "Album"
-              KeyType: "HASH"
-            - 
-              AttributeName: "Sales"
-              KeyType: "RANGE"
-          Projection: 
-            NonKeyAttributes: 
-              - "Artist"
-              - "NumberOfSongs"
-            ProjectionType: "INCLUDE"
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: Album
+          AttributeType: S
+        - AttributeName: Artist
+          AttributeType: S
+        - AttributeName: Sales
+          AttributeType: N
+        - AttributeName: NumberOfSongs
+          AttributeType: N
+      KeySchema:
+        - AttributeName: Album
+          KeyType: HASH
+        - AttributeName: Artist
+          KeyType: RANGE
+      ProvisionedThroughput:
+        ReadCapacityUnits: '5'
+        WriteCapacityUnits: '5'
+      TableName: myTableName
+      GlobalSecondaryIndexes:
+        - IndexName: myGSI
+          KeySchema:
+            - AttributeName: Sales
+              KeyType: HASH
+            - AttributeName: Artist
+              KeyType: RANGE
+          Projection:
+            NonKeyAttributes:
+              - Album
+              - NumberOfSongs
+            ProjectionType: INCLUDE
+          ProvisionedThroughput:
+            ReadCapacityUnits: '5'
+            WriteCapacityUnits: '5'
+        - IndexName: myGSI2
+          KeySchema:
+            - AttributeName: NumberOfSongs
+              KeyType: HASH
+            - AttributeName: Sales
+              KeyType: RANGE
+          Projection:
+            NonKeyAttributes:
+              - Album
+              - Artist
+            ProjectionType: INCLUDE
+          ProvisionedThroughput:
+            ReadCapacityUnits: '5'
+            WriteCapacityUnits: '5'
+      LocalSecondaryIndexes:
+        - IndexName: myLSI
+          KeySchema:
+            - AttributeName: Album
+              KeyType: HASH
+            - AttributeName: Sales
+              KeyType: RANGE
+          Projection:
+            NonKeyAttributes:
+              - Artist
+              - NumberOfSongs
+            ProjectionType: INCLUDE
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-DD-002 

 **Violation Description:** 

 DynamoDB Point-In-Time Recovery (PITR) is an automatic backup service for DynamoDB table data that helps protect your DynamoDB tables from accidental write or delete operations. Once enabled, PITR provides continuous backups that can be controlled using various programmatic parameters. PITR can also be used to restore table data from any point in time during the last 35 days, as well as any incremental backups of DynamoDB tables 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html' target='_blank'>here</a>