### PR TITLE
Fixed PR-AWS-CFR-AG-003: AWS API gateway request authorization is not set

### DIFF
--- a/api_gateway/api_gateway.yaml
+++ b/api_gateway/api_gateway.yaml
@@ -1,7 +1,6 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: |
-  Example REST API with a Lambda authorizer. To invoke the API, clients must include specific
-  header and query string values in the request.
+Description: "Example REST API with a Lambda authorizer. To invoke the API, clients\
+  \ must include specific\nheader and query string values in the request.\n"
 Resources:
   MyAPI:
     Type: AWS::ApiGateway::RestApi
@@ -9,184 +8,22 @@ Resources:
       Name: example-rest-api-with-auth
       EndpointConfiguration:
         Types:
-        - EDGE
+          - EDGE
   MyAuthorizer:
     Type: AWS::ApiGateway::Authorizer
     Properties:
-      AuthorizerCredentials: !GetAtt InvokeRole.Arn
-      AuthorizerUri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyAuthFunction.Arn}/invocations
+      AuthorizerCredentials: !GetAtt 'InvokeRole.Arn'
+      AuthorizerUri: !Sub 'arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyAuthFunction.Arn}/invocations'
       IdentitySource: method.request.header.HeaderAuth1,method.request.querystring.QueryString1
       Name: my-authorizer
-      RestApiId: !Ref MyAPI
-      Type: COGNITO_USER_POOLS
+      RestApiId: !Ref 'MyAPI'
+      Type: REQUEST
   Method:
     Type: AWS::ApiGateway::Method
     Properties:
       HttpMethod: GET
-      ResourceId: !GetAtt MyAPI.RootResourceId
-      RestApiId: !Ref MyAPI
-      AuthorizationType: CUSTOM
-      AuthorizerId: !Ref MyAuthorizer
-      Integration:
-        Type: AWS_PROXY
-        Uri: !Sub arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyProxyFunction.Arn}/invocations
-        Credentials: !GetAtt InvokeRole.Arn
-        IntegrationHttpMethod: POST
-  Deployment:
-    DependsOn: Method
-    Type: AWS::ApiGateway::Deployment
-    Properties:
-      RestApiId: !Ref MyAPI
-      StageName: test
-  InvokeRole:
-    Type: AWS::IAM::Role
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service:
-              - apigateway.amazonaws.com
-            Action:
-              - 'sts:AssumeRole'
-      Policies:
-        - PolicyName: invokeauth
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Effect: Allow
-                Action: lambda:InvokeFunction
-                Resource: !GetAtt MyAuthFunction.Arn
-        - PolicyName: invokelambdaproxy
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Effect: Allow
-                Action: lambda:InvokeFunction
-                Resource: !GetAtt MyProxyFunction.Arn
-  MyAuthFunction:
-    Type: AWS::Lambda::Function
-    Properties:
-      Runtime: nodejs12.x
-      Role: !GetAtt FunctionExecutionRole.Arn
-      Handler: index.handler
-      Code:
-        ZipFile: |
-          exports.handler = function(event, context, callback) {
-            console.log('Received event:', JSON.stringify(event, null, 2));
-            // A simple request-based authorizer example to demonstrate how to use request
-            // parameters to allow or deny a request. In this example, a request is
-            // authorized if the client-supplied HeaderAuth1 header and QueryString1
-            // query parameter match 'headerValue1' and 'queryValue1'.
-            // Retrieve request parameters from the Lambda function input:
-            var headers = event.headers;
-            var queryStringParameters = event.queryStringParameters;
-            var pathParameters = event.pathParameters;
-            var stageVariables = event.stageVariables;
-                
-            // Parse the input for the parameter values
-            var tmp = event.methodArn.split(':');
-            var apiGatewayArnTmp = tmp[5].split('/');
-            var awsAccountId = tmp[4];
-            var region = tmp[3];
-            var restApiId = apiGatewayArnTmp[0];
-            var stage = apiGatewayArnTmp[1];
-            var method = apiGatewayArnTmp[2];
-            var resource = '/'; // root resource
-            if (apiGatewayArnTmp[3]) {
-                resource += apiGatewayArnTmp[3];
-            }
-                
-            // Perform authorization to return the Allow policy for correct parameters and 
-            // the 'Unauthorized' error, otherwise.
-            var authResponse = {};
-            var condition = {};
-            condition.IpAddress = {};
-            
-            if (headers.HeaderAuth1 === "headerValue1"
-                && queryStringParameters.QueryString1 === "queryValue1") {
-                callback(null, generateAllow('me', event.methodArn));
-            }  else {
-                callback("Unauthorized");
-            }
-            }
-            
-            // Helper function to generate an IAM policy
-            var generatePolicy = function(principalId, effect, resource) {
-            // Required output:
-            var authResponse = {};
-            authResponse.principalId = principalId;
-            if (effect && resource) {
-                var policyDocument = {};
-                policyDocument.Version = '2012-10-17'; // default version
-                policyDocument.Statement = [];
-                var statementOne = {};
-                statementOne.Action = 'execute-api:Invoke'; // default action
-                statementOne.Effect = effect;
-                statementOne.Resource = resource;
-                policyDocument.Statement[0] = statementOne;
-                authResponse.policyDocument = policyDocument;
-            }
-            // Optional output with custom properties of the String, Number or Boolean type.
-            authResponse.context = {
-                "stringKey": "stringval",
-                "numberKey": 123,
-                "booleanKey": true
-            };
-            return authResponse;
-            }
-                
-            var generateAllow = function(principalId, resource) {
-                return generatePolicy(principalId, 'Allow', resource);
-            }
-                
-            var generateDeny = function(principalId, resource) {
-                return generatePolicy(principalId, 'Deny', resource);
-            }
-  MyProxyFunction:
-    Type: AWS::Lambda::Function
-    Properties:
-      Runtime: nodejs12.x
-      Role: !GetAtt FunctionExecutionRole.Arn
-      Handler: index.handler
-      Code:
-        ZipFile: |
-          exports.handler = async (event) => {
-              const response = {
-                  statusCode: 200,
-                  body: JSON.stringify('Hello from Lambda!'),
-              };
-              return response;
-          };
-  FunctionExecutionRole:
-    Type: AWS::IAM::Role
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service:
-              - lambda.amazonaws.com
-            Action:
-              - 'sts:AssumeRole'
-      ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
-  PetsResource:
-    Type: AWS::ApiGateway::Resource
-    Properties:
-      ParentId: !GetAtt
-        - MyAPI
-        - RootResourceId
-      PathPart: pets
-      RestApiId: !Ref MyAPI
-  Method:
-    Type: AWS::ApiGateway::Method
-    Properties:
-      HttpMethod: GET
-      ResourceId: !Ref PetsResource
-      RestApiId: !Ref MyAPI
+      ResourceId: !Ref 'PetsResource'
+      RestApiId: !Ref 'MyAPI'
       AuthorizationType: NONE
       Integration:
         Type: HTTP_PROXY
@@ -196,46 +33,148 @@ Resources:
     DependsOn: Method
     Type: AWS::ApiGateway::Deployment
     Properties:
-      RestApiId: !Ref MyAPI
+      RestApiId: !Ref 'MyAPI'
       StageName: tempstage
+  InvokeRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - apigateway.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Policies:
+        - PolicyName: invokeauth
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: lambda:InvokeFunction
+                Resource: !GetAtt 'MyAuthFunction.Arn'
+        - PolicyName: invokelambdaproxy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: lambda:InvokeFunction
+                Resource: !GetAtt 'MyProxyFunction.Arn'
+  MyAuthFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Runtime: nodejs12.x
+      Role: !GetAtt 'FunctionExecutionRole.Arn'
+      Handler: index.handler
+      Code:
+        ZipFile: "exports.handler = function(event, context, callback) {\n  console.log('Received\
+          \ event:', JSON.stringify(event, null, 2));\n  // A simple request-based\
+          \ authorizer example to demonstrate how to use request\n  // parameters\
+          \ to allow or deny a request. In this example, a request is\n  // authorized\
+          \ if the client-supplied HeaderAuth1 header and QueryString1\n  // query\
+          \ parameter match 'headerValue1' and 'queryValue1'.\n  // Retrieve request\
+          \ parameters from the Lambda function input:\n  var headers = event.headers;\n\
+          \  var queryStringParameters = event.queryStringParameters;\n  var pathParameters\
+          \ = event.pathParameters;\n  var stageVariables = event.stageVariables;\n\
+          \      \n  // Parse the input for the parameter values\n  var tmp = event.methodArn.split(':');\n\
+          \  var apiGatewayArnTmp = tmp[5].split('/');\n  var awsAccountId = tmp[4];\n\
+          \  var region = tmp[3];\n  var restApiId = apiGatewayArnTmp[0];\n  var stage\
+          \ = apiGatewayArnTmp[1];\n  var method = apiGatewayArnTmp[2];\n  var resource\
+          \ = '/'; // root resource\n  if (apiGatewayArnTmp[3]) {\n      resource\
+          \ += apiGatewayArnTmp[3];\n  }\n      \n  // Perform authorization to return\
+          \ the Allow policy for correct parameters and \n  // the 'Unauthorized'\
+          \ error, otherwise.\n  var authResponse = {};\n  var condition = {};\n \
+          \ condition.IpAddress = {};\n  \n  if (headers.HeaderAuth1 === \"headerValue1\"\
+          \n      && queryStringParameters.QueryString1 === \"queryValue1\") {\n \
+          \     callback(null, generateAllow('me', event.methodArn));\n  }  else {\n\
+          \      callback(\"Unauthorized\");\n  }\n  }\n  \n  // Helper function to\
+          \ generate an IAM policy\n  var generatePolicy = function(principalId, effect,\
+          \ resource) {\n  // Required output:\n  var authResponse = {};\n  authResponse.principalId\
+          \ = principalId;\n  if (effect && resource) {\n      var policyDocument\
+          \ = {};\n      policyDocument.Version = '2012-10-17'; // default version\n\
+          \      policyDocument.Statement = [];\n      var statementOne = {};\n  \
+          \    statementOne.Action = 'execute-api:Invoke'; // default action\n   \
+          \   statementOne.Effect = effect;\n      statementOne.Resource = resource;\n\
+          \      policyDocument.Statement[0] = statementOne;\n      authResponse.policyDocument\
+          \ = policyDocument;\n  }\n  // Optional output with custom properties of\
+          \ the String, Number or Boolean type.\n  authResponse.context = {\n    \
+          \  \"stringKey\": \"stringval\",\n      \"numberKey\": 123,\n      \"booleanKey\"\
+          : true\n  };\n  return authResponse;\n  }\n      \n  var generateAllow =\
+          \ function(principalId, resource) {\n      return generatePolicy(principalId,\
+          \ 'Allow', resource);\n  }\n      \n  var generateDeny = function(principalId,\
+          \ resource) {\n      return generatePolicy(principalId, 'Deny', resource);\n\
+          \  }\n"
+  MyProxyFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Runtime: nodejs12.x
+      Role: !GetAtt 'FunctionExecutionRole.Arn'
+      Handler: index.handler
+      Code:
+        ZipFile: "exports.handler = async (event) => {\n    const response = {\n \
+          \       statusCode: 200,\n        body: JSON.stringify('Hello from Lambda!'),\n\
+          \    };\n    return response;\n};\n"
+  FunctionExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+  PetsResource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      ParentId: !GetAtt 'MyAPI.RootResourceId'
+      PathPart: pets
+      RestApiId: !Ref 'MyAPI'
   TestStage:
     Type: AWS::ApiGateway::Stage
     Properties:
-      ClientCertificateId: ""
+      ClientCertificateId: ''
       StageName: test
-      RestApiId: !Ref MyAPI
-      DeploymentId: !Ref Deployment
-      Description: "test stage description"
+      RestApiId: !Ref 'MyAPI'
+      DeploymentId: !Ref 'Deployment'
+      Description: test stage description
       AccessLogSetting:
-        DestinationArn: !GetAtt MyLogGroup.Arn
-        Format: $context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] "$context.httpMethod $context.resourcePath $context.protocol" $context.status $context.responseLength $context.requestId
+        DestinationArn: !GetAtt 'MyLogGroup.Arn'
+        Format: >-
+          $context.identity.sourceIp $context.identity.caller $context.identity.user
+          [$context.requestTime] "$context.httpMethod $context.resourcePath $context.protocol"
+          $context.status $context.responseLength $context.requestId
   MyLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Join
         - '-'
-        - - !Ref MyAPI
+        - - !Ref 'MyAPI'
           - access-logs
   RequestValidator:
     Type: AWS::ApiGateway::RequestValidator
     Properties:
       Name: RequestValidatorAPI
-      RestApiId: !Ref MyAPI
-      ValidateRequestBody: !false
+      RestApiId: !Ref 'MyAPI'
+      ValidateRequestBody: !false ''
       ValidateRequestParameters: false
   MyWebACLAssociation:
-    Type: "AWS::WAFRegional::WebACLAssociation"
+    Type: AWS::WAFRegional::WebACLAssociation
     Properties:
-      ResourceArn:
-        Ref: PetsResource
-      WebACLId:
-        Ref: TestStage
+      ResourceArn: !Ref 'PetsResource'
+      WebACLId: !Ref 'TestStage'
   myDomainName:
-    Type: 'AWS::ApiGateway::DomainName'
+    Type: AWS::ApiGateway::DomainName
     Properties:
-      CertificateArn: !Ref myCertificate
-      DomainName: !Ref domainName
+      CertificateArn: !Ref 'myCertificate'
+      DomainName: !Ref 'domainName'
       SecurityPolicy: TLS_1_0
 Outputs:
   InvokeURL:
-    Value: !Sub https://${MyAPI}.execute-api.${AWS::Region}.amazonaws.com/test
+    Value: !Sub 'https://${MyAPI}.execute-api.${AWS::Region}.amazonaws.com/test'


### PR DESCRIPTION
**Violation Id:** PR-AWS-CFR-AG-003 

 **Violation Description:** 

 This policy identifies AWS API Gateways of protocol type REST for which the request authorisation is not set. The method request for API gateways takes the client input that is passed to the back end through the integration request. It is recommended to add authorization type to each of the method to add a layer of protection. 

 **How to Fix:** 

 Make sure you are following the Cloudformation template format presented <a href='https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigateway-restapi-endpointconfiguration.html' target='_blank'>here</a>